### PR TITLE
Migrate react-native-mmkv to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-native-edge-to-edge": "^1.7.0",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-keyboard-controller": "1.18.5",
-    "react-native-mmkv": "^3.3.1",
+    "react-native-mmkv": "^4.3.2",
     "react-native-nitro-modules": "^0.35.7",
     "react-native-quick-crypto": "^0.7.17",
     "react-native-reanimated": "~4.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ importers:
         specifier: 1.18.5
         version: 1.18.5(react-native-reanimated@4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.7)(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-mmkv:
-        specifier: ^3.3.1
-        version: 3.3.1(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        specifier: ^4.3.2
+        version: 4.3.2(react-native-nitro-modules@0.35.10(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-nitro-modules:
         specifier: ^0.35.7
         version: 0.35.10(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -5453,11 +5453,12 @@ packages:
       react-native: '*'
       react-native-reanimated: '>=3.0.0'
 
-  react-native-mmkv@3.3.1:
-    resolution: {integrity: sha512-LYamDWQirPTUJZ9Re+BkCD+zLRGNr+EVJDeIeblvoJXGatWy9PXnChtajDSLqwjX3EXVeUyjgrembs7wlBw9ug==}
+  react-native-mmkv@4.3.2:
+    resolution: {integrity: sha512-49OAyfkg0/TMWiWELZN6VuVQPZPhizwL4DTmp8b7B1md3dB/s3LH3mGfC3T+lp9W0y/rqxZMEnotLFTIbOAenQ==}
     peerDependencies:
       react: '*'
       react-native: '*'
+      react-native-nitro-modules: '*'
 
   react-native-nitro-modules@0.35.10:
     resolution: {integrity: sha512-KsySOAIkbSTjNiX2GvXiNT9P5DMeZd99yvtE/+Lw7RXV7Ztxh9Z+YyAbYkBqadhN5J/KXXuPjhRYgyLOIZgsbQ==}
@@ -12805,10 +12806,11 @@ snapshots:
       react-native-is-edge-to-edge: 1.2.1(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-reanimated: 4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.7)(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
 
-  react-native-mmkv@3.3.1(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+  react-native-mmkv@4.3.2(react-native-nitro-modules@0.35.10(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0)
+      react-native-nitro-modules: 0.35.10(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
 
   react-native-nitro-modules@0.35.10(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:

--- a/src/screens/pattern-review/pattern-review-screen.spec.tsx
+++ b/src/screens/pattern-review/pattern-review-screen.spec.tsx
@@ -14,7 +14,7 @@ jest.mock('@tanstack/react-query', () => ({
 
 jest.mock('react-native-mmkv', () => ({
   useMMKVBoolean: jest.fn(() => [false, jest.fn()]),
-  MMKV: jest.fn().mockImplementation(() => ({
+  createMMKV: jest.fn(() => ({
     getString: jest.fn(),
     set: jest.fn(),
     getBoolean: jest.fn(),

--- a/src/screens/patterns-screen/patterns-screen.spec.tsx
+++ b/src/screens/patterns-screen/patterns-screen.spec.tsx
@@ -19,7 +19,7 @@ jest.mock('@tanstack/react-query', () => ({
 
 jest.mock('react-native-mmkv', () => ({
   useMMKVBoolean: jest.fn(),
-  MMKV: jest.fn().mockImplementation(() => ({
+  createMMKV: jest.fn(() => ({
     getString: jest.fn(),
     set: jest.fn(),
     getBoolean: jest.fn(),

--- a/src/utils/mmkv/pattern-samples.spec.ts
+++ b/src/utils/mmkv/pattern-samples.spec.ts
@@ -4,7 +4,7 @@ import { storage } from './storage'
 
 // Mock the native MMKV to avoid requiring a real device environment
 jest.mock('react-native-mmkv', () => ({
-  MMKV: jest.fn().mockImplementation(() => ({
+  createMMKV: jest.fn(() => ({
     getString: jest.fn(),
     set: jest.fn(),
   })),

--- a/src/utils/mmkv/storage.ts
+++ b/src/utils/mmkv/storage.ts
@@ -1,8 +1,8 @@
 import { MMKV_KEYS } from '@/types/mmkv-keys'
-import { MMKV } from 'react-native-mmkv'
+import { createMMKV } from 'react-native-mmkv'
 
 // Singleton MMKV instance (default ID: 'mmkv.default')
-export const storage = new MMKV()
+export const storage = createMMKV()
 
 /**
  * Updates the last read SMS timestamp.


### PR DESCRIPTION
## Summary

Migrates `react-native-mmkv` `^3.3.1` → `^4.3.2` per the official [V4 Upgrade Guide](https://github.com/mrousavy/react-native-mmkv/blob/main/docs/V4_UPGRADE_GUIDE.md). V4 is a full rewrite onto Nitro.

Applied all 3 documented breaking changes:
- `new MMKV()` → `createMMKV()` — the `MMKV` JS class no longer exists, it's now purely native (`src/utils/mmkv/storage.ts`)
- `.delete(key)` → `.remove(key)` — not used anywhere in this codebase, nothing to change
- `AppGroup` → `AppGroupIdentifier` in iOS `Info.plist` — not applicable, this app is Android-only

Also updated the 3 test files that manually mocked the `MMKV` class constructor (`jest.mock('react-native-mmkv', () => ({ MMKV: ... }))`) to mock `createMMKV` instead.

`react-native-nitro-modules` is already at `^0.35.7` (bumped in #39), which satisfies v4's Nitro requirement (`>= 0.35.0` per mmkv's own 4.2.0 release notes).

## Why this got a real device test

The previous PR (#39) taught a hard lesson: bumping `react-native-unistyles` passed type-check/lint/jest cleanly, but silently failed to compile at the native layer (`Unresolved reference 'CxxPart'`) until an actual Gradle build was run. Since mmkv v4 is also a full native rewrite, the same class of risk applies here, so this one got the same treatment.

## Test plan
- [x] `pnpm type-check` / `pnpm lint` / `pnpm test` — clean, 377 tests passing
- [x] `expo prebuild --platform android` + `./gradlew assembleDebug` — `BUILD SUCCESSFUL`
- [x] Installed the APK on an emulator, connected to Metro, and confirmed via logcat that the new Nitro-based MMKV native module initializes correctly, creates the `mmkv.default` instance, and writes to its storage file — no crashes
- [x] App renders the real onboarding screen (not a red-screen error)