### PR TITLE
Fix EAS submit track: beta -> alpha (fixes 13/13 QA release failures)

### DIFF
--- a/.github/workflows/release-qa-android.yml
+++ b/.github/workflows/release-qa-android.yml
@@ -27,7 +27,7 @@ jobs:
           mkdir -p .github/keys
           echo "$GOOGLE_SERVICE_ACCOUNT_KEY" > .github/keys/play.json
 
-      - name: EAS build & auto-submit (Android Beta track)
+      - name: EAS build & auto-submit (Android QA - Play Console "Alpha" track)
         uses: ./.github/actions/eas-build
         with:
           platform: android

--- a/README.md
+++ b/README.md
@@ -126,17 +126,17 @@ This project uses EAS (Expo Application Services) with GitHub Actions for Androi
 
    - This updates `package.json` version, commits, and pushes the tag.
 
-2. Publish GitHub Release (triggers QA to Play Beta)
+2. Publish GitHub Release (triggers QA to Play Console's "Alpha" closed-testing track)
    - GitHub → Releases → “Draft new release” → select the new tag → Publish.
-   - This triggers the workflow to build an AAB and auto-submit to Play Beta.
+   - This triggers the workflow to build an AAB and auto-submit to the "Alpha" track.
 
 3. Monitor QA build and submission
    - Actions → QA Android Release (EAS) → view logs.
    - You can also track the build on Expo: `eas build:list` or the EAS dashboard.
 
-4. Test on device from Play Beta
-   - Ensure your tester account is added to the Beta track in Play Console.
-   - Install/update the app from Google Play (Beta) and verify functionality.
+4. Test on device from the "Alpha" track
+   - Ensure your tester account is added to the "Alpha" closed-testing track in Play Console.
+   - Install/update the app from Google Play and verify functionality.
 
 5. Promote to Production (version parity)
    - GitHub → Actions → “Production Android Release (EAS)” → Run workflow.
@@ -153,13 +153,13 @@ This project uses EAS (Expo Application Services) with GitHub Actions for Androi
   - `GOOGLE_SERVICE_ACCOUNT_KEY`: Google Play service account JSON (full contents)
 - Google Play Console
   - App created with package `com.rosewallet.app`
-  - Testing track enabled (Beta) with testers configured
+  - "Alpha" closed-testing track enabled with testers configured
 - EAS Project
   - Project linked (see `extra.eas.projectId` in `app.config.ts`)
   - `eas.json` profiles:
     - `development`: internal dev client (APK)
     - `preview`: internal preview (APK)
-    - `beta`: Play Beta submission (AAB)
+    - `beta`: QA build/submission, targets Play Console's "Alpha" track (AAB) — named `beta` as our internal QA profile, distinct from Play's own track naming
     - `production`: Play Production (AAB, autoIncrement)
 
 ### Versioning
@@ -174,13 +174,13 @@ This project uses EAS (Expo Application Services) with GitHub Actions for Androi
   - This bumps `package.json` version, commits, and creates a Git tag.
   - We do not run `expo prebuild` in the version hook.
 
-### QA (Play Beta) flow
+### QA (Play Console "Alpha" track) flow
 
 1. Create a Git tag and publish a GitHub Release for it.
 2. Workflow `QA Android Release (EAS)` runs automatically and:
    - Builds Android AAB with profile `beta`
-   - Auto-submits to Google Play Beta track
-3. Install from Play Beta on device and test.
+   - Auto-submits to Google Play Console's "Alpha" closed-testing track
+3. Install from the "Alpha" track on device and test.
 
 ### Production flow
 

--- a/eas.json
+++ b/eas.json
@@ -34,7 +34,7 @@
   "submit": {
     "beta": {
       "android": {
-        "track": "beta",
+        "track": "alpha",
         "serviceAccountKeyPath": ".github/keys/play.json"
       }
     },


### PR DESCRIPTION
## Summary

Every automated QA release since the CI automation was set up has failed — **13 out of 13 runs**, 100% failure rate — with:

```
Google Api Error: Invalid request - Precondition check failed.
Fastlane supply failed
```

## Root cause

`eas.json`'s `beta` submit profile targets Play Console's legacy `track: "beta"` identifier. Checked Play Console directly: this app only has a legacy **"Alpha"** closed-testing track (which already has a real release, `v1.2.4` — landed there some other way, since the automated path could never reach any track) and a separate **custom-named** closed-testing track literally labeled "Beta" that has *never* had a release ("There is no release on this track").

A custom-named track does not map to Play's reserved legacy `beta` API identifier — only the original default track does. So every submit attempt targeting `"beta"` was hitting a track that doesn't exist from the API's point of view, while `"alpha"` was the one actually working all along.

## Changes
- `eas.json`: `submit.beta.android.track`: `"beta"` → `"alpha"`
- `.github/workflows/release-qa-android.yml`: corrected the step's human-readable name (no functional change — `profile: beta` / `submit-profile: beta` are just our own internal EAS profile names, unrelated to the Play Console track name, and didn't need to change)
- `README.md`: corrected several "Play Beta" references that described the same wrong assumption baked into the original setup

## Test plan
- [x] `eas.json` validated as JSON, `eas config --profile beta --platform android` resolves cleanly
- [ ] Next tagged release should be verified against Play Console to confirm the submission actually lands on the "Alpha" track this time