### PR TITLE
Fix add-expense screen re-showing already-confirmed transactions

### DIFF
--- a/src/hooks/use-delete-expense.ts
+++ b/src/hooks/use-delete-expense.ts
@@ -10,8 +10,8 @@ export function useDeleteExpense() {
   return useMutation({
     mutationFn: (id: number) => deleteTransaction(id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: MONTH_TOTAL_QUERY_KEY })
-      queryClient.invalidateQueries({ queryKey: EXPENSES_BY_MONTH_QUERY_KEY })
+      queryClient.invalidateQueries({ queryKey: [MONTH_TOTAL_QUERY_KEY] })
+      queryClient.invalidateQueries({ queryKey: [EXPENSES_BY_MONTH_QUERY_KEY] })
       queryClient.invalidateQueries({ queryKey: RECENT_EXPENSES_QUERY_KEY })
       queryClient.invalidateQueries({ queryKey: [GETTING_STARTED_TRANSACTIONS_QUERY_KEY] })
     },

--- a/src/hooks/use-get-expenses-by-month.ts
+++ b/src/hooks/use-get-expenses-by-month.ts
@@ -4,8 +4,8 @@ import { getMonthRange } from '@/utils/date/get-month-range'
 import { GroupedExpenseItem, groupExpensesByDate } from '@/utils/expense/group-expenses-by-date'
 import { useQuery } from '@tanstack/react-query'
 
-export const EXPENSES_BY_MONTH_QUERY_KEY = ['expenses-by-month'] as const
-export const MONTH_TOTAL_QUERY_KEY = ['month-total'] as const
+export const EXPENSES_BY_MONTH_QUERY_KEY = 'expenses-by-month'
+export const MONTH_TOTAL_QUERY_KEY = 'month-total'
 
 export interface MonthExpensesData {
   groupedItems: GroupedExpenseItem[]
@@ -23,7 +23,7 @@ function transformExpenses(expenses: Expense[]): MonthExpensesData {
 
 export function useGetExpensesByMonth(year: number, month: number) {
   return useQuery({
-    queryKey: [...EXPENSES_BY_MONTH_QUERY_KEY, year, month],
+    queryKey: [EXPENSES_BY_MONTH_QUERY_KEY, year, month],
     queryFn: () => fetchExpensesByMonth(year, month),
     select: transformExpenses,
   })
@@ -32,7 +32,7 @@ export function useGetExpensesByMonth(year: number, month: number) {
 export function useGetMonthTotal(year: number, month: number) {
   const { start, end } = getMonthRange(year, month)
   return useQuery<ExpenseMonthStats>({
-    queryKey: [...MONTH_TOTAL_QUERY_KEY, year, month],
+    queryKey: [MONTH_TOTAL_QUERY_KEY, year, month],
     queryFn: () => getExpenseStats({ filter: { startDate: start, endDate: end } }),
   })
 }

--- a/src/hooks/use-save-expense.ts
+++ b/src/hooks/use-save-expense.ts
@@ -5,6 +5,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { EXPENSES_BY_MONTH_QUERY_KEY, MONTH_TOTAL_QUERY_KEY } from './use-get-expenses-by-month'
 import { GETTING_STARTED_TRANSACTIONS_QUERY_KEY } from './use-getting-started'
 import { RECENT_EXPENSES_QUERY_KEY } from './use-get-recent-expenses'
+import { SMS_TRANSACTIONS_QUERY_KEY } from './use-sms-transactions'
 
 interface SaveExpenseParams {
   transaction: Transaction
@@ -35,10 +36,11 @@ export function useSaveExpense() {
   return useMutation({
     mutationFn: saveExpenseWithPattern,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: MONTH_TOTAL_QUERY_KEY })
-      queryClient.invalidateQueries({ queryKey: EXPENSES_BY_MONTH_QUERY_KEY })
+      queryClient.invalidateQueries({ queryKey: [MONTH_TOTAL_QUERY_KEY] })
+      queryClient.invalidateQueries({ queryKey: [EXPENSES_BY_MONTH_QUERY_KEY] })
       queryClient.invalidateQueries({ queryKey: RECENT_EXPENSES_QUERY_KEY })
       queryClient.invalidateQueries({ queryKey: [GETTING_STARTED_TRANSACTIONS_QUERY_KEY] })
+      queryClient.invalidateQueries({ queryKey: [SMS_TRANSACTIONS_QUERY_KEY] })
     },
   })
 }

--- a/src/hooks/use-sms-transactions.ts
+++ b/src/hooks/use-sms-transactions.ts
@@ -52,9 +52,11 @@ async function fetchSMSTransactions(): Promise<Transaction[]> {
   return [...fromPatterns, ...fromCandidates].sort((a, b) => a.transactionDate - b.transactionDate)
 }
 
+export const SMS_TRANSACTIONS_QUERY_KEY = 'sms-transactions'
+
 export function useSMSTransactions() {
   const query = useQuery({
-    queryKey: ['sms-transactions'],
+    queryKey: [SMS_TRANSACTIONS_QUERY_KEY],
     queryFn: fetchSMSTransactions,
   })
 

--- a/src/hooks/use-update-expense.ts
+++ b/src/hooks/use-update-expense.ts
@@ -36,8 +36,8 @@ export function useUpdateExpense() {
   return useMutation({
     mutationFn: updateExpenseWithNames,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: MONTH_TOTAL_QUERY_KEY })
-      queryClient.invalidateQueries({ queryKey: EXPENSES_BY_MONTH_QUERY_KEY })
+      queryClient.invalidateQueries({ queryKey: [MONTH_TOTAL_QUERY_KEY] })
+      queryClient.invalidateQueries({ queryKey: [EXPENSES_BY_MONTH_QUERY_KEY] })
       queryClient.invalidateQueries({ queryKey: RECENT_EXPENSES_QUERY_KEY })
       queryClient.invalidateQueries({ queryKey: [GETTING_STARTED_TRANSACTIONS_QUERY_KEY] })
     },


### PR DESCRIPTION
## Summary
- Confirming an expense (`useSaveExpense`) never invalidated the `sms-transactions` query used by `useSMSTransactions`, and the app's `QueryClient` has a 1-minute default `staleTime`. So going back from add-expense and hitting the FAB again shortly after served the stale cached list instead of refetching — already-confirmed transactions reappeared for re-review.
- Added `SMS_TRANSACTIONS_QUERY_KEY` export and invalidate it in `useSaveExpense`'s `onSuccess`.
- Normalized query key constants (`MONTH_TOTAL_QUERY_KEY`, `EXPENSES_BY_MONTH_QUERY_KEY`) to plain strings, wrapped in arrays at each call site, matching the style used by the other query key constants in the codebase.

## Test plan
- [x] `pnpm type-check`
- [x] `pnpm test` (377 tests passing)
- [ ] Manual: confirm 3 expenses via add-expense, go back, press FAB again immediately — verify the same 3 transactions no longer reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)