### PR TITLE
Make add-expense review instant and migrate to ReviewTxn

### DIFF
--- a/src/components/expense-review/expense-review.tsx
+++ b/src/components/expense-review/expense-review.tsx
@@ -2,7 +2,7 @@ import { QuickCategoryChips } from '@/components/quick-category-chips/quick-cate
 import { Input } from '@/components/ui/input/input'
 import { Text } from '@/components/ui/text/text'
 import { Category } from '@/db/schema'
-import type { Transaction } from '@/types/sms/transaction'
+import type { ReviewTxn } from '@/types/sms-parsing'
 import { formatDateTime } from '@/utils/date/format-date-time'
 import { formatCurrency } from '@/utils/formatter/format-currency'
 import { MessageSquare, Store, Tag } from 'lucide-react-native'
@@ -12,7 +12,7 @@ import { useUnistyles } from 'react-native-unistyles'
 import { styles } from './expense-review.style'
 
 interface Props {
-  transaction: Transaction
+  transaction: ReviewTxn
   style?: ViewStyle
   amountValue: string
   merchantValue: string
@@ -49,21 +49,19 @@ export function ExpenseReview({
         >
           {formatCurrency(transaction.amount)}
         </Text>
-        {transaction.merchant && (
-          <View style={styles.merchantDetected}>
-            <Store
-              size={14}
-              color={theme.colors.surface}
-              opacity={0.8}
-            />
-            <Text
-              variant='pSm'
-              style={styles.merchantText}
-            >
-              {transaction.merchant}
-            </Text>
-          </View>
-        )}
+        <View style={styles.merchantDetected}>
+          <Store
+            size={14}
+            color={theme.colors.surface}
+            opacity={0.8}
+          />
+          <Text
+            variant='pSm'
+            style={styles.merchantText}
+          >
+            {transaction.merchantRaw || 'Unknown'}
+          </Text>
+        </View>
       </View>
 
       <View style={styles.smsSection}>
@@ -75,12 +73,12 @@ export function ExpenseReview({
             />
           </View>
           <View style={styles.smsMeta}>
-            <Text variant='pMdBold'>{transaction.message.address}</Text>
+            <Text variant='pMdBold'>{transaction.sender}</Text>
             <Text
               variant='pSm'
               color='muted'
             >
-              {formatDateTime(new Date(transaction.message.date))}
+              {formatDateTime(new Date(transaction.date))}
             </Text>
           </View>
         </View>
@@ -89,7 +87,7 @@ export function ExpenseReview({
           style={styles.smsBody}
           selectable
         >
-          {transaction.message.body}
+          {transaction.body}
         </Text>
       </View>
 

--- a/src/components/pattern-review-pane/pattern-review-pane.tsx
+++ b/src/components/pattern-review-pane/pattern-review-pane.tsx
@@ -4,7 +4,7 @@ import { Card } from '@/components/ui/card/card'
 import { GETTING_STARTED_PATTERNS_QUERY_KEY } from '@/hooks/use-getting-started'
 import { finalizeReview, reviewNext, reviewPrev, reviewReset, reviewUpdateItem } from '@/hooks/use-store'
 import { MMKV_KEYS } from '@/types/mmkv-keys'
-import type { Transaction } from '@/types/sms/transaction'
+import type { ReviewTxn } from '@/types/sms-parsing'
 import { useQueryClient } from '@tanstack/react-query'
 import { useTourGuide } from '@wrack/react-native-tour-guide'
 import { useRouter } from 'expo-router'
@@ -16,7 +16,7 @@ import { useUnistyles } from 'react-native-unistyles'
 import { styles } from './pattern-review-pane.styes'
 
 interface Props {
-  sample: Transaction | undefined
+  sample: ReviewTxn | undefined
   index: number
   total: number
 }
@@ -66,13 +66,13 @@ export function PatternReviewPane({ sample, index, total }: Props) {
   const isLast = index === total - 1
 
   const [amountValue, setAmountValue] = useState(sample ? String(sample.amount) : '')
-  const [merchantValue, setMerchantValue] = useState(sample?.merchant ?? '')
+  const [merchantValue, setMerchantValue] = useState(sample?.merchantRaw ?? '')
 
   // Sync local state when sample changes
   useEffect(() => {
     if (!sample) return
     setAmountValue(String(sample.amount))
-    setMerchantValue(sample.merchant)
+    setMerchantValue(sample.merchantRaw)
   }, [sample])
 
   if (!sample) return null
@@ -80,7 +80,7 @@ export function PatternReviewPane({ sample, index, total }: Props) {
   const persist = () => {
     const parsed = parseFloat(amountValue)
     const amount = isNaN(parsed) ? sample.amount : parsed
-    reviewUpdateItem(index, { amount, merchant: merchantValue })
+    reviewUpdateItem(index, { amount, merchantRaw: merchantValue })
   }
 
   const handleNextOrApprove = () => {
@@ -110,11 +110,11 @@ export function PatternReviewPane({ sample, index, total }: Props) {
       <View ref={viewRef}>
         <Card>
           <SmsReviewItem
-            id={sample.message.id}
-            bankName={sample.bankName}
-            date={sample.message.date}
-            messageBody={sample.message.body}
-            merchant={sample.merchant}
+            id={String(sample.smsId)}
+            bankName={sample.bank ?? 'Unknown'}
+            date={sample.date}
+            messageBody={sample.body}
+            merchant={sample.merchantRaw}
             amount={sample.amount}
             amountValue={amountValue}
             merchantValue={merchantValue}

--- a/src/hooks/use-save-expense.spec.tsx
+++ b/src/hooks/use-save-expense.spec.tsx
@@ -1,0 +1,66 @@
+import { saveExpense } from '@/services/database/save-expense'
+import type { ReviewTxn } from '@/types/sms-parsing'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react-native'
+import React from 'react'
+import { useSaveExpense } from './use-save-expense'
+import { SMS_TRANSACTIONS_QUERY_KEY } from './use-sms-transactions'
+
+jest.mock('@/services/database/save-expense', () => ({
+  saveExpense: jest.fn().mockResolvedValue({ merchantId: 1, categoryId: 1, smsId: 1 }),
+}))
+
+jest.mock('rose-sms-reader', () => ({
+  checkSMSPermission: jest.fn(),
+  requestSMSPermission: jest.fn(),
+  isAvailable: jest.fn(),
+  readSMS: jest.fn(),
+}))
+
+const mockSaveExpense = saveExpense as jest.Mock
+
+function makeTransaction(smsId: number): ReviewTxn {
+  return {
+    smsId,
+    amount: 250,
+    type: 'debit',
+    merchantRaw: 'Swiggy',
+    date: 1000,
+    patternId: 7,
+    sender: 'AD-HDFCBK-T',
+    body: 'Rs.250 debited',
+  }
+}
+
+describe('useSaveExpense', () => {
+  it('removes the saved transaction from the cached SMS list without refetching', async () => {
+    // Infinite gcTime so no garbage-collection timer keeps jest from exiting.
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { gcTime: Infinity } },
+    })
+    const transactions = [makeTransaction(1), makeTransaction(2), makeTransaction(3)]
+    queryClient.setQueryData([SMS_TRANSACTIONS_QUERY_KEY], transactions)
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+    const { result } = renderHook(() => useSaveExpense(), { wrapper })
+
+    result.current.mutate({
+      transaction: transactions[1],
+      amount: 250,
+      merchantName: 'Swiggy',
+      categoryName: 'Food',
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockSaveExpense).toHaveBeenCalledTimes(1)
+    expect(mockSaveExpense).toHaveBeenCalledWith(expect.objectContaining({ smsId: 2, smsDate: 1000, patternId: 7 }))
+    const cached = queryClient.getQueryData<ReviewTxn[]>([SMS_TRANSACTIONS_QUERY_KEY])
+    expect(cached?.map((t) => t.smsId)).toEqual([1, 3])
+    // Surgical cache update, not an invalidation — the query must stay fresh
+    // so the review screen never refetches (and re-syncs SMS) mid-session.
+    expect(queryClient.getQueryState([SMS_TRANSACTIONS_QUERY_KEY])?.isInvalidated).toBe(false)
+  })
+})

--- a/src/hooks/use-save-expense.ts
+++ b/src/hooks/use-save-expense.ts
@@ -1,6 +1,6 @@
 import { TRANSACTION_TYPE } from '@/db/schema'
 import { saveExpense } from '@/services/database/save-expense'
-import type { Transaction } from '@/types/sms/transaction'
+import type { ReviewTxn } from '@/types/sms-parsing'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { EXPENSES_BY_MONTH_QUERY_KEY, MONTH_TOTAL_QUERY_KEY } from './use-get-expenses-by-month'
 import { GETTING_STARTED_TRANSACTIONS_QUERY_KEY } from './use-getting-started'
@@ -8,7 +8,7 @@ import { RECENT_EXPENSES_QUERY_KEY } from './use-get-recent-expenses'
 import { SMS_TRANSACTIONS_QUERY_KEY } from './use-sms-transactions'
 
 interface SaveExpenseParams {
-  transaction: Transaction
+  transaction: ReviewTxn
   amount: number
   merchantName: string
   categoryName: string
@@ -18,10 +18,9 @@ async function saveExpenseWithPattern(params: SaveExpenseParams) {
   const { transaction, amount, merchantName, categoryName } = params
 
   return saveExpense({
-    smsBody: transaction.message.body,
-    smsSender: transaction.message.address,
-    smsDate: transaction.message.date,
-    merchantName: merchantName || transaction.merchant || 'Unknown',
+    smsId: transaction.smsId,
+    smsDate: transaction.date,
+    merchantName: merchantName || transaction.merchantRaw || 'Unknown',
     categoryName: categoryName || 'Other',
     patternId: transaction.patternId,
     amount,
@@ -35,12 +34,20 @@ export function useSaveExpense() {
 
   return useMutation({
     mutationFn: saveExpenseWithPattern,
-    onSuccess: () => {
+    onSuccess: async (_result, { transaction }) => {
       queryClient.invalidateQueries({ queryKey: [MONTH_TOTAL_QUERY_KEY] })
       queryClient.invalidateQueries({ queryKey: [EXPENSES_BY_MONTH_QUERY_KEY] })
       queryClient.invalidateQueries({ queryKey: RECENT_EXPENSES_QUERY_KEY })
       queryClient.invalidateQueries({ queryKey: [GETTING_STARTED_TRANSACTIONS_QUERY_KEY] })
-      queryClient.invalidateQueries({ queryKey: [SMS_TRANSACTIONS_QUERY_KEY] })
+
+      // Drop the saved SMS from the cached review list instead of invalidating:
+      // a refetch re-runs the whole SMS sync pipeline (native read + queue
+      // triage) between every confirm. Cancel any in-flight refetch first so
+      // its stale result can't resurrect the item.
+      await queryClient.cancelQueries({ queryKey: [SMS_TRANSACTIONS_QUERY_KEY] })
+      queryClient.setQueryData<ReviewTxn[]>([SMS_TRANSACTIONS_QUERY_KEY], (old) =>
+        old?.filter((t) => t.smsId !== transaction.smsId)
+      )
     },
   })
 }

--- a/src/hooks/use-sms-transactions.ts
+++ b/src/hooks/use-sms-transactions.ts
@@ -1,8 +1,8 @@
-import { TRANSACTION_TYPE } from '@/db/schema'
 import { SMSDataExtractor } from '@/services/sms-parsing/sms-data-extractor-service'
 import { SmsSyncService } from '@/services/sms-parsing/sms-sync-service'
 import { MMKV_KEYS } from '@/types/mmkv-keys'
-import type { Transaction } from '@/types/sms/transaction'
+import type { ReviewTxn } from '@/types/sms-parsing'
+import { TRANSACTION_TYPE } from '@/db/schema'
 import { storage } from '@/utils/mmkv/storage'
 import { useQuery } from '@tanstack/react-query'
 
@@ -12,7 +12,7 @@ function getOneMonthAgoTimestamp(): number {
   return d.getTime()
 }
 
-async function fetchSMSTransactions(): Promise<Transaction[]> {
+async function fetchSMSTransactions(): Promise<ReviewTxn[]> {
   const lastRead = storage.getNumber(MMKV_KEYS.SMS.LAST_READ_AT)
   const startTimestamp = typeof lastRead === 'number' ? lastRead : getOneMonthAgoTimestamp()
   const endTimestamp = Date.now()
@@ -20,19 +20,21 @@ async function fetchSMSTransactions(): Promise<Transaction[]> {
   const result = await SmsSyncService.syncWithQueue({ startTimestamp, endTimestamp })
 
   // Pattern-matched messages: deterministic extraction, linked to their pattern.
-  const fromPatterns: Transaction[] = result.extracted.map((e) => ({
-    id: e.sms.id,
+  // Everything here is queue-row-backed after syncWithQueue, so sms.id is the DB id.
+  const fromPatterns: ReviewTxn[] = result.extracted.map((e) => ({
+    smsId: Number(e.sms.id),
     patternId: e.patternId,
     amount: e.amount,
-    merchant: e.merchantRaw || 'Unknown',
-    bankName: 'Unknown',
-    transactionDate: e.sms.date,
-    message: e.sms,
+    type: e.type,
+    merchantRaw: e.merchantRaw ?? '',
+    date: e.sms.date,
+    sender: e.sms.address,
+    body: e.sms.body,
   }))
 
   // Unmatched candidates: parser-library bootstrap so new banks show up before
   // their pattern exists; reviewing them in the patterns screen creates one.
-  const fromCandidates: Transaction[] = []
+  const fromCandidates: ReviewTxn[] = []
   for (const candidate of result.candidates) {
     const intent = candidate.type === TRANSACTION_TYPE.Credit ? 'income' : 'expense'
     const fields = SMSDataExtractor.extract(candidate.sms.body, intent)
@@ -40,16 +42,18 @@ async function fetchSMSTransactions(): Promise<Transaction[]> {
     if (!amount || amount <= 0) continue
 
     fromCandidates.push({
-      id: candidate.sms.id,
+      smsId: Number(candidate.sms.id),
       amount,
-      merchant: fields.merchant || 'Unknown',
-      bankName: fields.bank?.name || 'Unknown',
-      transactionDate: candidate.sms.date,
-      message: candidate.sms,
+      type: candidate.type,
+      merchantRaw: fields.merchant ?? '',
+      date: candidate.sms.date,
+      sender: candidate.sms.address,
+      body: candidate.sms.body,
+      bank: fields.bank?.name,
     })
   }
 
-  return [...fromPatterns, ...fromCandidates].sort((a, b) => a.transactionDate - b.transactionDate)
+  return [...fromPatterns, ...fromCandidates].sort((a, b) => a.date - b.date)
 }
 
 export const SMS_TRANSACTIONS_QUERY_KEY = 'sms-transactions'

--- a/src/hooks/use-store.spec.ts
+++ b/src/hooks/use-store.spec.ts
@@ -2,22 +2,8 @@ import { act } from '@testing-library/react-native'
 import { finalizeReview, reviewNext, reviewPrev, reviewReset, reviewUpdateItem, useAppStore } from './use-store'
 
 const sampleTxns = [
-  {
-    id: '1',
-    amount: 100,
-    merchant: 'A',
-    bankName: 'B',
-    transactionDate: 1,
-    message: { id: 'm1', body: 'x', address: 'a', date: 1, read: true },
-  },
-  {
-    id: '2',
-    amount: 200,
-    merchant: 'C',
-    bankName: 'D',
-    transactionDate: 2,
-    message: { id: 'm2', body: 'y', address: 'b', date: 2, read: true },
-  },
+  { smsId: 1, amount: 100, type: 'debit', merchantRaw: 'A', bank: 'B', date: 1, sender: 'a', body: 'x' },
+  { smsId: 2, amount: 200, type: 'debit', merchantRaw: 'C', bank: 'D', date: 2, sender: 'b', body: 'y' },
 ] as any
 
 jest.mock('@/services/sms-parsing/pattern-approval-service', () => ({
@@ -60,9 +46,9 @@ describe('useAppStore', () => {
   it('updates a specific transaction via patch', () => {
     act(() => {
       useAppStore.getState().setPatternReview(sampleTxns, 'N')
-      reviewUpdateItem(1, { merchant: 'ZZ' } as any)
+      reviewUpdateItem(1, { merchantRaw: 'ZZ' })
     })
-    expect(useAppStore.getState().patternReview.transactions[1].merchant).toBe('ZZ')
+    expect(useAppStore.getState().patternReview.transactions[1].merchantRaw).toBe('ZZ')
   })
 
   it('finalizeReview persists and updates template', async () => {

--- a/src/hooks/use-store.ts
+++ b/src/hooks/use-store.ts
@@ -1,5 +1,5 @@
 import { PatternApprovalService } from '@/services/sms-parsing/pattern-approval-service'
-import type { Transaction } from '@/types/sms/transaction'
+import type { ReviewTxn } from '@/types/sms-parsing'
 import { create, type StoreApi, type UseBoundStore } from 'zustand'
 import { immer } from 'zustand/middleware/immer'
 
@@ -17,11 +17,11 @@ const createSelectors = <S extends UseBoundStore<StoreApi<object>>>(_store: S) =
 
 interface AppState {
   patternReview: {
-    transactions: Transaction[]
+    transactions: ReviewTxn[]
     name: string
     currentIndex: number
   }
-  setPatternReview: (transactions: Transaction[], name: string) => void
+  setPatternReview: (transactions: ReviewTxn[], name: string) => void
   editExpenseModal: {
     isOpen: boolean
     expenseId: number | null
@@ -39,7 +39,7 @@ const useAppStoreBase = create<AppState>()(
       name: '',
       currentIndex: 0,
     },
-    setPatternReview: (transactions: Transaction[], name: string) =>
+    setPatternReview: (transactions: ReviewTxn[], name: string) =>
       set((state) => {
         state.patternReview.transactions = transactions
         state.patternReview.name = name
@@ -79,7 +79,7 @@ export const reviewPrev = () =>
 export const reviewReset = () =>
   useAppStoreBase.setState((state) => ({ patternReview: { ...state.patternReview, currentIndex: 0 } }))
 
-export const reviewUpdateItem = (index: number, patch: Partial<Transaction>) =>
+export const reviewUpdateItem = (index: number, patch: Partial<ReviewTxn>) =>
   useAppStoreBase.setState((state) => {
     const { transactions } = state.patternReview
     const next = transactions.map((t, i) => (i === index ? { ...t, ...patch } : t))

--- a/src/screens/add-expense/add-expense.tsx
+++ b/src/screens/add-expense/add-expense.tsx
@@ -22,7 +22,7 @@ import { styles } from './add-expense.style'
 export default function AddExpenseScreen() {
   const { theme } = useUnistyles()
   const router = useRouter()
-  const { data: transactions = [], isLoading, isFetching, errorMessage, refetch } = useSMSTransactions()
+  const { data: transactions = [], isLoading, errorMessage, refetch } = useSMSTransactions()
   const { data: favoriteCategories = [], isLoading: isFavoriteCategoriesLoading } = useGetFavoriteCategories()
   const { mutate: saveFavoriteCategories } = useSetFavoriteCategories()
   const { mutate: saveExpense, isPending: isSaving } = useSaveExpense()
@@ -42,12 +42,12 @@ export default function AddExpenseScreen() {
     const tx = transactions[currentIndex]
     if (!tx) return
     setAmountValue(String(tx.amount ?? ''))
-    setMerchantValue(tx.merchant ?? '')
+    setMerchantValue(tx.merchantRaw)
 
     // Auto-fill category based on merchant-category mapping
     async function autoFillCategory() {
-      if (tx.merchant) {
-        const category = await getCategoryByMerchantName(tx.merchant)
+      if (tx.merchantRaw) {
+        const category = await getCategoryByMerchantName(tx.merchantRaw)
         setCategoryValue(category ?? '')
       } else {
         setCategoryValue('')
@@ -63,7 +63,7 @@ export default function AddExpenseScreen() {
   function handleReject() {
     const tx = transactions[currentIndex]
     if (tx) {
-      updateLastReadSmsTimestamp(tx.transactionDate)
+      updateLastReadSmsTimestamp(tx.date)
     }
 
     if (isLastItem) {
@@ -86,11 +86,11 @@ export default function AddExpenseScreen() {
       },
       {
         onSuccess: () => {
+          // The saved item is removed from the cached list, so the next
+          // transaction slides into currentIndex — advancing would skip one.
           if (isLastItem) {
             setIsCompleted(true)
-            return
           }
-          setCurrentIndex(currentIndex + 1)
         },
         onError: (e) => {
           console.warn('Confirm expense failed', e)
@@ -103,7 +103,7 @@ export default function AddExpenseScreen() {
     router.back()
   }
 
-  if (isLoading || isFetching) {
+  if (isLoading) {
     return (
       <View style={styles.centeredContainer}>
         <Loading

--- a/src/screens/pattern-review/pattern-review-screen.spec.tsx
+++ b/src/screens/pattern-review/pattern-review-screen.spec.tsx
@@ -51,22 +51,8 @@ describe('PatternReviewScreen', () => {
   it('renders header and closes via button (resets and navigates back)', () => {
     mockPatternReview.mockReturnValue({
       transactions: [
-        {
-          id: '1',
-          amount: 100,
-          merchant: 'A',
-          bankName: 'B',
-          transactionDate: 1,
-          message: { id: 'm1', body: 'x', address: 'a', date: 1, read: true },
-        },
-        {
-          id: '2',
-          amount: 200,
-          merchant: 'C',
-          bankName: 'D',
-          transactionDate: 2,
-          message: { id: 'm2', body: 'y', address: 'b', date: 2, read: true },
-        },
+        { smsId: 1, amount: 100, type: 'debit', merchantRaw: 'A', bank: 'B', date: 1, sender: 'a', body: 'x' },
+        { smsId: 2, amount: 200, type: 'debit', merchantRaw: 'C', bank: 'D', date: 2, sender: 'b', body: 'y' },
       ],
       name: 'PAT',
       currentIndex: 0,

--- a/src/services/database/save-expense.ts
+++ b/src/services/database/save-expense.ts
@@ -1,15 +1,15 @@
-import { TRANSACTION_TYPE, type TransactionType } from '@/db/schema'
+import { SMS_MATCH_STATUS, TRANSACTION_TYPE, type TransactionType } from '@/db/schema'
 import { updateLastReadSmsTimestamp } from '@/utils/mmkv/storage'
 import { getOrCreateCategoryIdByName } from './categories-repository'
 import { ensureMerchantCategoryGroup } from './merchant-category-groups-repository'
 import { getOrCreateMerchantIdByName } from './merchants-repository'
 import { ensurePatternSmsGroupLink } from './patterns-repository'
-import { insertEncryptedSms } from './sms-messages-repository'
+import { updateSmsMatchStatusByIds } from './sms-messages-repository'
 import { insertTransaction } from './transactions-repository'
 
 interface SaveExpense {
-  smsBody: string
-  smsSender: string
+  /** Residual-queue row of the source SMS — every reviewed expense is queue-backed. */
+  smsId: number
   smsDate: number
   merchantName: string
   categoryName: string
@@ -24,16 +24,12 @@ export async function saveExpense(input: SaveExpense) {
   try {
     const merchantName = input.merchantName.trim()
     const categoryName = input.categoryName.trim()
-    const { description, patternId, smsBody, smsDate, smsSender } = input
+    const { description, patternId, smsId, smsDate } = input
 
-    const [merchantId, categoryId, smsId] = await Promise.all([
+    const [merchantId, categoryId] = await Promise.all([
       getOrCreateMerchantIdByName(merchantName),
       getOrCreateCategoryIdByName(categoryName),
-      insertEncryptedSms({
-        sender: smsSender,
-        body: smsBody,
-        date: smsDate,
-      }),
+      updateSmsMatchStatusByIds([smsId], SMS_MATCH_STATUS.Matched),
     ])
 
     await ensureMerchantCategoryGroup(merchantId, categoryId)
@@ -55,7 +51,7 @@ export async function saveExpense(input: SaveExpense) {
       merchantId,
     })
 
-    updateLastReadSmsTimestamp(input.smsDate)
+    updateLastReadSmsTimestamp(smsDate)
 
     return { merchantId, categoryId, smsId, patternId }
   } catch (error) {

--- a/src/services/database/sms-messages-repository.ts
+++ b/src/services/database/sms-messages-repository.ts
@@ -22,32 +22,6 @@ export function computeSmsHash(input: SmsInput): string {
 }
 
 /**
- * Persist an SMS that became an expense. Upserts on the content hash, so an SMS
- * already sitting in the unmatched queue is flipped to matched instead of duplicated.
- */
-export async function insertEncryptedSms(input: SmsInput): Promise<number> {
-  const db = getDrizzleDb()
-  const smsHash = computeSmsHash(input)
-
-  await db
-    .insert(smsMessages)
-    .values({
-      sender: encryptText(input.sender),
-      body: encryptText(input.body),
-      dateTime: new Date(input.date),
-      smsHash,
-      matchStatus: SMS_MATCH_STATUS.Matched,
-    })
-    .onConflictDoUpdate({
-      target: smsMessages.smsHash,
-      set: { matchStatus: SMS_MATCH_STATUS.Matched },
-    })
-
-  const rows = await db.select().from(smsMessages).where(eq(smsMessages.smsHash, smsHash))
-  return rows[0]?.id as number
-}
-
-/**
  * Add transaction-relevant SMS to the residual queue. Content-hash conflicts are
  * ignored, so re-scanning an overlapping time window is a no-op.
  */

--- a/src/services/sms-parsing/pattern-approval-service.spec.ts
+++ b/src/services/sms-parsing/pattern-approval-service.spec.ts
@@ -1,6 +1,6 @@
 import { incrementPatternUsageByName, updatePatternTemplateByName } from '@/services/database/patterns-repository'
 import { getUnmatchedSms } from '@/services/database/sms-messages-repository'
-import type { Transaction } from '@/types/sms/transaction'
+import type { ReviewTxn } from '@/types/sms-parsing'
 import { setPatternSamplesByName } from '@/utils/mmkv/pattern-samples'
 import { extractWithTemplate } from '@/utils/pattern/extract-with-template'
 import { PatternApprovalService } from './pattern-approval-service'
@@ -24,14 +24,16 @@ const mockGetUnmatched = getUnmatchedSms as jest.Mock
 const mockSetSamples = setPatternSamplesByName as jest.Mock
 
 let nextId = 1
-function makeSample(body: string, amount: number, merchant: string): Transaction {
+function makeSample(body: string, amount: number, merchant: string): ReviewTxn {
   return {
-    id: String(nextId++),
+    smsId: nextId++,
     amount,
-    merchant,
-    bankName: 'HDFC',
-    transactionDate: nextId,
-    message: { id: String(nextId), body, address: 'AD-HDFCBK-T', date: nextId, read: true, type: 1 },
+    type: 'debit',
+    merchantRaw: merchant,
+    bank: 'HDFC',
+    date: nextId,
+    sender: 'AD-HDFCBK-T',
+    body,
   }
 }
 

--- a/src/services/sms-parsing/pattern-approval-service.ts
+++ b/src/services/sms-parsing/pattern-approval-service.ts
@@ -1,6 +1,6 @@
 import { incrementPatternUsageByName, updatePatternTemplateByName } from '@/services/database/patterns-repository'
 import { getUnmatchedSms } from '@/services/database/sms-messages-repository'
-import type { Transaction } from '@/types/sms/transaction'
+import type { ReviewTxn } from '@/types/sms-parsing'
 import { setPatternSamplesByName } from '@/utils/mmkv/pattern-samples'
 import { buildTemplateFromLabels } from '@/utils/pattern/build-template-from-labels'
 import { extractWithTemplate } from '@/utils/pattern/extract-with-template'
@@ -22,7 +22,7 @@ export interface ApprovalResult {
  * After saving, sweeps the residual queue so the approval retroactively pays off.
  */
 export class PatternApprovalService {
-  static async approve(name: string, samples: Transaction[]): Promise<ApprovalResult> {
+  static async approve(name: string, samples: ReviewTxn[]): Promise<ApprovalResult> {
     if (!name) throw new Error('Pattern name is required')
     if (samples.length === 0) throw new Error('At least one reviewed sample is required')
 
@@ -30,9 +30,9 @@ export class PatternApprovalService {
 
     const built = buildTemplateFromLabels(
       samples.map((t) => ({
-        body: t.message.body,
+        body: t.body,
         amount: t.amount,
-        merchant: t.merchant && t.merchant !== 'Unknown' ? t.merchant : undefined,
+        merchant: t.merchantRaw || undefined,
       }))
     )
 

--- a/src/services/sms-parsing/pattern-discovery-service.ts
+++ b/src/services/sms-parsing/pattern-discovery-service.ts
@@ -1,6 +1,7 @@
 import { PATTERN_STATUS, TRANSACTION_TYPE } from '@/db/schema'
 import { upsertPatternsByGrouping } from '@/services/database/patterns-repository'
-import type { DistinctPattern, Transaction } from '@/types/sms/transaction'
+import type { ReviewTxn } from '@/types/sms-parsing'
+import type { DistinctPattern } from '@/types/sms/transaction'
 import { murmurHash32 } from '@/utils/hash/murmur32'
 import { setPatternSamplesByName } from '@/utils/mmkv/pattern-samples'
 import { groupByTemplate } from '@/utils/pattern/group-by-template'
@@ -14,7 +15,7 @@ const SAMPLES_PER_PATTERN = 3
 
 interface CandidateSample {
   candidate: CandidateSms
-  transaction: Transaction
+  transaction: ReviewTxn
 }
 
 /**
@@ -38,12 +39,14 @@ export class PatternDiscoveryService {
       samples.push({
         candidate,
         transaction: {
-          id: candidate.sms.id,
+          smsId: Number(candidate.sms.id),
           amount,
-          merchant: fields.merchant || 'Unknown',
-          bankName: fields.bank?.name || 'Unknown',
-          transactionDate: candidate.sms.date,
-          message: candidate.sms,
+          type: candidate.type,
+          merchantRaw: fields.merchant ?? '',
+          date: candidate.sms.date,
+          sender: candidate.sms.address,
+          body: candidate.sms.body,
+          bank: fields.bank?.name,
         },
       })
     }
@@ -54,11 +57,7 @@ export class PatternDiscoveryService {
 
     const drafts: DistinctPattern[] = groups.map((group, index) => {
       const first = group.items[0].transaction
-      const { template } = proposeSlots(
-        first.message.body,
-        first.amount,
-        first.merchant !== 'Unknown' ? first.merchant : undefined
-      )
+      const { template } = proposeSlots(first.body, first.amount, first.merchantRaw || undefined)
 
       return {
         id: String(index + 1),

--- a/src/services/sms-parsing/sms-sync-service.ts
+++ b/src/services/sms-parsing/sms-sync-service.ts
@@ -19,6 +19,7 @@ export interface ExtractedSms {
   sms: SMSMessage
   patternId: number
   patternName: string
+  type: TransactionType
   amount: number
   merchantRaw?: string
 }
@@ -86,6 +87,7 @@ export class SmsSyncService {
             sms,
             patternId: match.value.id,
             patternName: match.value.name,
+            type: match.value.type,
             amount: extraction.amount,
             merchantRaw: extraction.merchantRaw,
           })

--- a/src/types/mmkv-keys.ts
+++ b/src/types/mmkv-keys.ts
@@ -13,7 +13,8 @@ export const MMKV_KEYS = {
   },
   PATTERNS: {
     IS_PATTERN_DISCOVERY_COMPLETED: 'patterns.is_pattern_discovery_completed',
-    DISCOVERY_SAMPLES_V1: 'patterns.discovery_samples_v1',
+    // V2: samples stored as ReviewTxn (flat sms fields); V1 held the legacy Transaction shape.
+    DISCOVERY_SAMPLES_V2: 'patterns.discovery_samples_v2',
     PATTERN_GUIDE_SEEN: 'patterns.pattern_guide_seen',
     REVIEW_GUIDE_SEEN: 'patterns.review_guide_seen',
   },

--- a/src/types/sms-parsing.ts
+++ b/src/types/sms-parsing.ts
@@ -10,6 +10,14 @@ export interface ExtractedTxn {
   patternId?: number
 }
 
+/** An ExtractedTxn joined with its decrypted source SMS, for review screens. */
+export interface ReviewTxn extends ExtractedTxn {
+  sender: string
+  body: string
+  /** Best-effort bank display name from the bootstrap extractor. */
+  bank?: string
+}
+
 /** A discovered pattern awaiting user review. Field names match the patterns table. */
 export interface PatternDraft
   extends Pick<NewPattern, 'name' | 'groupingPattern' | 'extractionPattern' | 'type' | 'sender'> {

--- a/src/types/sms/transaction.ts
+++ b/src/types/sms/transaction.ts
@@ -1,21 +1,10 @@
 import type { PatternStatus, TransactionType } from '@/db/schema'
-import type { SMSMessage } from 'rose-sms-reader'
+import type { ReviewTxn } from '@/types/sms-parsing'
 
 export type { SMSMessage } from 'rose-sms-reader'
 
 /** @deprecated only sms-data-extractor still speaks this — use TransactionType from '@/db/schema' */
 export type Intent = 'not_txn' | 'expense' | 'income'
-
-/** @deprecated legacy pipeline shape — use ExtractedTxn from '@/types/sms-parsing' */
-export interface Transaction {
-  id: string
-  amount: number
-  merchant: string
-  bankName: string
-  transactionDate: number
-  message: SMSMessage
-  patternId?: number
-}
 
 /** @deprecated legacy pipeline shape — use PatternDraft from '@/types/sms-parsing' */
 export interface DistinctPattern {
@@ -23,7 +12,7 @@ export interface DistinctPattern {
   template: string
   groupingTemplate: string
   occurrences: number
-  transactions: Transaction[]
+  transactions: ReviewTxn[]
   patternType: TransactionType
   status: PatternStatus
 }

--- a/src/utils/mmkv/pattern-samples.spec.ts
+++ b/src/utils/mmkv/pattern-samples.spec.ts
@@ -54,9 +54,9 @@ describe('setPatternSamplesByName', () => {
 
     setPatternSamplesByName('HDFC', samples)
 
-    expect(getSpy).toHaveBeenCalledWith(MMKV_KEYS.PATTERNS.DISCOVERY_SAMPLES_V1)
+    expect(getSpy).toHaveBeenCalledWith(MMKV_KEYS.PATTERNS.DISCOVERY_SAMPLES_V2)
     expect(setSpy).toHaveBeenCalledTimes(1)
-    expect(setSpy).toHaveBeenCalledWith(MMKV_KEYS.PATTERNS.DISCOVERY_SAMPLES_V1, JSON.stringify({ HDFC: samples }))
+    expect(setSpy).toHaveBeenCalledWith(MMKV_KEYS.PATTERNS.DISCOVERY_SAMPLES_V2, JSON.stringify({ HDFC: samples }))
   })
 
   it('merges with existing map (overwrites given name)', () => {
@@ -68,7 +68,7 @@ describe('setPatternSamplesByName', () => {
     setPatternSamplesByName('SBI', samples)
 
     expect(setSpy).toHaveBeenCalledWith(
-      MMKV_KEYS.PATTERNS.DISCOVERY_SAMPLES_V1,
+      MMKV_KEYS.PATTERNS.DISCOVERY_SAMPLES_V2,
       JSON.stringify({ ...existing, SBI: samples })
     )
   })
@@ -80,6 +80,6 @@ describe('setPatternSamplesByName', () => {
     const samples = [{ id: 'z' } as any]
     setPatternSamplesByName('AXIS', samples)
 
-    expect(setSpy).toHaveBeenCalledWith(MMKV_KEYS.PATTERNS.DISCOVERY_SAMPLES_V1, JSON.stringify({ AXIS: samples }))
+    expect(setSpy).toHaveBeenCalledWith(MMKV_KEYS.PATTERNS.DISCOVERY_SAMPLES_V2, JSON.stringify({ AXIS: samples }))
   })
 })

--- a/src/utils/mmkv/pattern-samples.ts
+++ b/src/utils/mmkv/pattern-samples.ts
@@ -1,31 +1,31 @@
 import { MMKV_KEYS } from '@/types/mmkv-keys'
-import type { Transaction } from '@/types/sms/transaction'
+import type { ReviewTxn } from '@/types/sms-parsing'
 import { storage } from './storage'
 
-export function getPatternSamplesByName(name: string): Transaction[] {
-  const json = storage.getString(MMKV_KEYS.PATTERNS.DISCOVERY_SAMPLES_V1)
+export function getPatternSamplesByName(name: string): ReviewTxn[] {
+  const json = storage.getString(MMKV_KEYS.PATTERNS.DISCOVERY_SAMPLES_V2)
   if (!json) return []
   try {
-    const map = JSON.parse(json) as Record<string, Transaction[]>
+    const map = JSON.parse(json) as Record<string, ReviewTxn[]>
     return map[name] || []
   } catch {
     return []
   }
 }
 
-export function setPatternSamplesByName(name: string, samples: Transaction[]) {
-  const json = storage.getString(MMKV_KEYS.PATTERNS.DISCOVERY_SAMPLES_V1)
+export function setPatternSamplesByName(name: string, samples: ReviewTxn[]) {
+  const json = storage.getString(MMKV_KEYS.PATTERNS.DISCOVERY_SAMPLES_V2)
   if (!json) {
     const map = { [name]: samples }
-    storage.set(MMKV_KEYS.PATTERNS.DISCOVERY_SAMPLES_V1, JSON.stringify(map))
+    storage.set(MMKV_KEYS.PATTERNS.DISCOVERY_SAMPLES_V2, JSON.stringify(map))
     return
   }
   try {
-    const map = JSON.parse(json) as Record<string, Transaction[]>
+    const map = JSON.parse(json) as Record<string, ReviewTxn[]>
     const newMap = { ...map, [name]: samples }
-    storage.set(MMKV_KEYS.PATTERNS.DISCOVERY_SAMPLES_V1, JSON.stringify(newMap))
+    storage.set(MMKV_KEYS.PATTERNS.DISCOVERY_SAMPLES_V2, JSON.stringify(newMap))
   } catch {
     const map = { [name]: samples }
-    storage.set(MMKV_KEYS.PATTERNS.DISCOVERY_SAMPLES_V1, JSON.stringify(map))
+    storage.set(MMKV_KEYS.PATTERNS.DISCOVERY_SAMPLES_V2, JSON.stringify(map))
   }
 }


### PR DESCRIPTION
## Problem

Two issues in the add-expense review flow, plus a type debt:

1. **Loading screen between every SMS** — confirming an expense invalidated the `sms-transactions` query, re-running the entire sync pipeline (native SMS read + full queue re-triage) per confirm, while the screen swapped to the full-screen "Reading Messages" loader on any fetch.
2. **Hidden skip bug** — the refetched list already excluded the saved SMS (#42) *and* `onSuccess` advanced `currentIndex`, so every confirm silently skipped the next message. The loader was masking it.
3. The whole review pipeline spoke the deprecated `Transaction` shape.

## Fix

**Instant review flow**
- Save success surgically drops the item from the query cache (`setQueryData`) instead of invalidating — no re-sync between confirms. In-flight refetches are cancelled first so a stale result can't resurrect a confirmed item.
- Confirm no longer advances the index; the next transaction slides into place (fixes the skip).
- Full-screen loader gated on `isLoading` only, so background focus-refetches don't blank the screen.

**`ReviewTxn` migration (deprecated `Transaction` deleted)**
- New `ReviewTxn` = `ExtractedTxn` + `sender`/`body`/optional `bank` — feeds both add-expense and pattern-review flows. `ExtractedSms` now carries the pattern's transaction `type`.
- `saveExpense` takes `smsId` and flips the queue row to `matched` instead of re-encrypting/re-inserting the SMS; `insertEncryptedSms` removed (encryption happens once, at enqueue).
- `'Unknown'` sentinel removed from the data layer; `merchantRaw` is empty when unknown and the UI renders the fallback label.
- Pattern samples stored under `DISCOVERY_SAMPLES_V2`. Old V1 blobs are orphaned — fine while the app is in closed testing; discovery re-creates samples on its next run.

## Test plan

- [x] Full suite: 73 suites / 385 tests; type-check and lint clean
- [x] New `use-save-expense` spec: cache filtered by `smsId`, query not invalidated, `saveExpense` called with `smsId`
- [ ] Device: confirm → next card is instant; one discovery → review → approve cycle (V2 samples path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)