### PR TITLE
Fix rejected SMS resurfacing on next sync

### DIFF
--- a/src/hooks/use-reject-expense.spec.tsx
+++ b/src/hooks/use-reject-expense.spec.tsx
@@ -1,0 +1,81 @@
+import { updateSmsMatchStatusByIds } from '@/services/database/sms-messages-repository'
+import type { ReviewTxn } from '@/types/sms-parsing'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react-native'
+import React from 'react'
+import { useRejectExpense } from './use-reject-expense'
+import { SMS_TRANSACTIONS_QUERY_KEY } from './use-sms-transactions'
+
+jest.mock('@/services/database/sms-messages-repository', () => ({
+  updateSmsMatchStatusByIds: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('rose-sms-reader', () => ({
+  checkSMSPermission: jest.fn(),
+  requestSMSPermission: jest.fn(),
+  isAvailable: jest.fn(),
+  readSMS: jest.fn(),
+}))
+
+const mockUpdateSmsMatchStatusByIds = updateSmsMatchStatusByIds as jest.Mock
+
+function makeTransaction(smsId: number): ReviewTxn {
+  return {
+    smsId,
+    amount: 250,
+    type: 'debit',
+    merchantRaw: 'Swiggy',
+    date: 1000,
+    patternId: 7,
+    sender: 'AD-HDFCBK-T',
+    body: 'Rs.250 debited',
+  }
+}
+
+describe('useRejectExpense', () => {
+  it('marks the SMS ignored and removes it from the cached SMS list without refetching', async () => {
+    // Infinite gcTime so no garbage-collection timer keeps jest from exiting.
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { gcTime: Infinity } },
+    })
+    const transactions = [makeTransaction(1), makeTransaction(2), makeTransaction(3)]
+    queryClient.setQueryData([SMS_TRANSACTIONS_QUERY_KEY], transactions)
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+    const { result } = renderHook(() => useRejectExpense(), { wrapper })
+
+    result.current.mutate(transactions[1])
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockUpdateSmsMatchStatusByIds).toHaveBeenCalledWith([2], 'ignored')
+    const cached = queryClient.getQueryData<ReviewTxn[]>([SMS_TRANSACTIONS_QUERY_KEY])
+    expect(cached?.map((t) => t.smsId)).toEqual([1, 3])
+    // Surgical cache update, not an invalidation — the query must stay fresh
+    // so the review screen never refetches (and re-syncs SMS) mid-session.
+    expect(queryClient.getQueryState([SMS_TRANSACTIONS_QUERY_KEY])?.isInvalidated).toBe(false)
+  })
+
+  it('never lets a rejected SMS resurface — it stays excluded regardless of DB status filtering', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { gcTime: Infinity } },
+    })
+    const transactions = [makeTransaction(1)]
+    queryClient.setQueryData([SMS_TRANSACTIONS_QUERY_KEY], transactions)
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+    const { result } = renderHook(() => useRejectExpense(), { wrapper })
+
+    result.current.mutate(transactions[0])
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    // 'ignored', not 'unmatched' — the residual queue only re-triages unmatched
+    // rows, so this is what keeps a rejected SMS from reappearing on next sync.
+    expect(mockUpdateSmsMatchStatusByIds).toHaveBeenCalledWith([1], 'ignored')
+  })
+})

--- a/src/hooks/use-reject-expense.ts
+++ b/src/hooks/use-reject-expense.ts
@@ -1,0 +1,22 @@
+import { SMS_MATCH_STATUS } from '@/db/schema'
+import { updateSmsMatchStatusByIds } from '@/services/database/sms-messages-repository'
+import type { ReviewTxn } from '@/types/sms-parsing'
+import { updateLastReadSmsTimestamp } from '@/utils/mmkv/storage'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { removeReviewedSmsFromCache } from './use-sms-transactions'
+
+async function rejectTransaction(transaction: ReviewTxn) {
+  await updateSmsMatchStatusByIds([transaction.smsId], SMS_MATCH_STATUS.Ignored)
+  updateLastReadSmsTimestamp(transaction.date)
+}
+
+export function useRejectExpense() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: rejectTransaction,
+    onSuccess: async (_result, transaction) => {
+      await removeReviewedSmsFromCache(queryClient, transaction.smsId)
+    },
+  })
+}

--- a/src/hooks/use-save-expense.ts
+++ b/src/hooks/use-save-expense.ts
@@ -5,7 +5,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { EXPENSES_BY_MONTH_QUERY_KEY, MONTH_TOTAL_QUERY_KEY } from './use-get-expenses-by-month'
 import { GETTING_STARTED_TRANSACTIONS_QUERY_KEY } from './use-getting-started'
 import { RECENT_EXPENSES_QUERY_KEY } from './use-get-recent-expenses'
-import { SMS_TRANSACTIONS_QUERY_KEY } from './use-sms-transactions'
+import { removeReviewedSmsFromCache } from './use-sms-transactions'
 
 interface SaveExpenseParams {
   transaction: ReviewTxn
@@ -40,14 +40,7 @@ export function useSaveExpense() {
       queryClient.invalidateQueries({ queryKey: RECENT_EXPENSES_QUERY_KEY })
       queryClient.invalidateQueries({ queryKey: [GETTING_STARTED_TRANSACTIONS_QUERY_KEY] })
 
-      // Drop the saved SMS from the cached review list instead of invalidating:
-      // a refetch re-runs the whole SMS sync pipeline (native read + queue
-      // triage) between every confirm. Cancel any in-flight refetch first so
-      // its stale result can't resurrect the item.
-      await queryClient.cancelQueries({ queryKey: [SMS_TRANSACTIONS_QUERY_KEY] })
-      queryClient.setQueryData<ReviewTxn[]>([SMS_TRANSACTIONS_QUERY_KEY], (old) =>
-        old?.filter((t) => t.smsId !== transaction.smsId)
-      )
+      await removeReviewedSmsFromCache(queryClient, transaction.smsId)
     },
   })
 }

--- a/src/hooks/use-sms-transactions.ts
+++ b/src/hooks/use-sms-transactions.ts
@@ -4,7 +4,7 @@ import { MMKV_KEYS } from '@/types/mmkv-keys'
 import type { ReviewTxn } from '@/types/sms-parsing'
 import { TRANSACTION_TYPE } from '@/db/schema'
 import { storage } from '@/utils/mmkv/storage'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, type QueryClient } from '@tanstack/react-query'
 
 function getOneMonthAgoTimestamp(): number {
   const d = new Date()
@@ -57,6 +57,17 @@ async function fetchSMSTransactions(): Promise<ReviewTxn[]> {
 }
 
 export const SMS_TRANSACTIONS_QUERY_KEY = 'sms-transactions'
+
+/**
+ * Drop a reviewed (saved or rejected) SMS from the cached review list instead of
+ * invalidating: a refetch re-runs the whole SMS sync pipeline (native read + queue
+ * triage) between every review action. Cancel any in-flight refetch first so its
+ * stale result — fetched before this SMS's DB status changed — can't resurrect it.
+ */
+export async function removeReviewedSmsFromCache(queryClient: QueryClient, smsId: number) {
+  await queryClient.cancelQueries({ queryKey: [SMS_TRANSACTIONS_QUERY_KEY] })
+  queryClient.setQueryData<ReviewTxn[]>([SMS_TRANSACTIONS_QUERY_KEY], (old) => old?.filter((t) => t.smsId !== smsId))
+}
 
 export function useSMSTransactions() {
   const query = useQuery({

--- a/src/screens/add-expense/add-expense.tsx
+++ b/src/screens/add-expense/add-expense.tsx
@@ -7,13 +7,13 @@ import { Text } from '@/components/ui/text/text'
 import { DEFAULT_CATEGORIES } from '@/constants/categories'
 import { useGetFavoriteCategories, useSetFavoriteCategories } from '@/hooks/use-categories'
 import { useRefetchOnFocus } from '@/hooks/use-refetch-on-focus'
+import { useRejectExpense } from '@/hooks/use-reject-expense'
 import { useSaveExpense } from '@/hooks/use-save-expense'
 import { useSMSTransactions } from '@/hooks/use-sms-transactions'
 import { getCategoryByMerchantName } from '@/services/database/categories-repository'
-import { updateLastReadSmsTimestamp } from '@/utils/mmkv/storage'
 import { useRouter } from 'expo-router'
 import { Check, MessageSquareText, X } from 'lucide-react-native'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { View } from 'react-native'
 import { KeyboardAwareScrollView } from 'react-native-keyboard-controller'
 import { useUnistyles } from 'react-native-unistyles'
@@ -26,7 +26,7 @@ export default function AddExpenseScreen() {
   const { data: favoriteCategories = [], isLoading: isFavoriteCategoriesLoading } = useGetFavoriteCategories()
   const { mutate: saveFavoriteCategories } = useSetFavoriteCategories()
   const { mutate: saveExpense, isPending: isSaving } = useSaveExpense()
-  const [currentIndex, setCurrentIndex] = useState(0)
+  const { mutate: rejectExpense, isPending: isRejecting } = useRejectExpense()
   const [amountValue, setAmountValue] = useState('')
   const [merchantValue, setMerchantValue] = useState('')
   const [categoryValue, setCategoryValue] = useState('')
@@ -35,11 +35,20 @@ export default function AddExpenseScreen() {
 
   useRefetchOnFocus(refetch)
 
-  const isLastItem = currentIndex >= transactions.length - 1
+  // Confirming/rejecting removes the item from the list rather than advancing
+  // through it, so the original count has to be captured once for "X of Y".
+  const initialTotalRef = useRef<number | null>(null)
+  if (transactions.length > 0 && initialTotalRef.current === null) {
+    initialTotalRef.current = transactions.length
+  }
+  const totalCount = initialTotalRef.current ?? transactions.length
+
+  const isLastItem = transactions.length <= 1
+  const isBusy = isSaving || isRejecting
 
   // Prefill inputs when the current item changes (including auto-fill category)
   useEffect(() => {
-    const tx = transactions[currentIndex]
+    const tx = transactions[0]
     if (!tx) return
     setAmountValue(String(tx.amount ?? ''))
     setMerchantValue(tx.merchantRaw)
@@ -54,27 +63,32 @@ export default function AddExpenseScreen() {
       }
     }
     autoFillCategory()
-  }, [transactions, currentIndex])
+  }, [transactions])
 
   function handleSaveCategories(categories: string[]) {
     saveFavoriteCategories(categories)
   }
 
   function handleReject() {
-    const tx = transactions[currentIndex]
-    if (tx) {
-      updateLastReadSmsTimestamp(tx.date)
-    }
+    const tx = transactions[0]
+    if (!tx) return
 
-    if (isLastItem) {
-      setIsCompleted(true)
-      return
-    }
-    setCurrentIndex(currentIndex + 1)
+    rejectExpense(tx, {
+      onSuccess: () => {
+        // The rejected item is removed from the cached list, so the next
+        // transaction slides into position 0 on its own.
+        if (isLastItem) {
+          setIsCompleted(true)
+        }
+      },
+      onError: (e) => {
+        console.warn('Reject expense failed', e)
+      },
+    })
   }
 
   function handleConfirm() {
-    const tx = transactions[currentIndex]
+    const tx = transactions[0]
     if (!tx) return
 
     saveExpense(
@@ -87,7 +101,7 @@ export default function AddExpenseScreen() {
       {
         onSuccess: () => {
           // The saved item is removed from the cached list, so the next
-          // transaction slides into currentIndex — advancing would skip one.
+          // transaction slides into position 0 on its own.
           if (isLastItem) {
             setIsCompleted(true)
           }
@@ -159,13 +173,13 @@ export default function AddExpenseScreen() {
               variant='pSmBold'
               color='muted'
             >
-              {transactions.length - currentIndex} of {transactions.length} remaining
+              {transactions.length} of {totalCount} remaining
             </Text>
           </View>
         </View>
         <View style={styles.cardContainer}>
           <ExpenseReview
-            transaction={transactions[currentIndex]}
+            transaction={transactions[0]}
             amountValue={amountValue}
             merchantValue={merchantValue}
             categoryValue={categoryValue}
@@ -186,27 +200,27 @@ export default function AddExpenseScreen() {
       />
       <View style={styles.actionsRow}>
         <IconButton
-          disabled={isSaving}
+          disabled={isBusy}
           onPress={handleReject}
         >
-          <View style={[styles.iconCircleBase, styles.rejectCircle(isSaving)]}>
+          <View style={[styles.iconCircleBase, styles.rejectCircle(isBusy)]}>
             <X
               size={32}
-              color={styles.rejectColor(isSaving).color}
+              color={styles.rejectColor(isBusy).color}
             />
           </View>
           <Text
             variant='pSm'
-            style={styles.rejectColor(isSaving)}
+            style={styles.rejectColor(isBusy)}
           >
             Reject
           </Text>
         </IconButton>
         <IconButton
-          disabled={isSaving}
+          disabled={isBusy}
           onPress={handleConfirm}
         >
-          <View style={[styles.iconCircleBase, styles.confirmCircle(isSaving)]}>
+          <View style={[styles.iconCircleBase, styles.confirmCircle(isBusy)]}>
             <Check
               size={32}
               color={theme.colors.surface}
@@ -214,7 +228,7 @@ export default function AddExpenseScreen() {
           </View>
           <Text
             variant='pSmBold'
-            style={styles.confirmColor(isSaving)}
+            style={styles.confirmColor(isBusy)}
           >
             Confirm
           </Text>


### PR DESCRIPTION
## Summary
- Reject only bumped the last-read-SMS bookmark, which the residual queue (since #43) doesn't consult — `getUnmatchedSms()` selects every row still `unmatched` with no timestamp filter. So a rejected SMS stayed `unmatched` forever and reappeared on the very next sync, unlike a confirmed one, which already gets a durable `matched` status via #45.
- Added `useRejectExpense`, mirroring `useSaveExpense`: marks the SMS row `ignored` (same durable status family) before dropping it from the cached review list.
- Extracted the cancel-then-splice cache logic both hooks need into `removeReviewedSmsFromCache` so it can't drift out of sync between the two paths again.
- Confirm/reject both just remove the reviewed item and let the next one slide into place now, so `add-expense`'s `currentIndex` was dead state; removed it, and fixed the "X of Y remaining" pill it silently broke (always read "N of N" once nothing advanced an index).

## Test plan
- [x] `pnpm type-check`
- [x] `pnpm test` (387 tests passing)
- [ ] Manual: reject a few SMS in add-expense, go back, reopen after the cache goes stale (or restart the app) — verify the rejected ones do not reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)