### PR TITLE
Improve first-time extraction accuracy; normalizer v2 + versioning spec

### DIFF
--- a/docs/NORMALIZER_VERSIONING.md
+++ b/docs/NORMALIZER_VERSIONING.md
@@ -1,0 +1,126 @@
+# Normalizer Versioning & Pattern Recompute
+
+**Status:** not implemented — this document is the implementation spec.
+**Prerequisite reading:** none beyond the file pointers below; this doc is self-contained.
+
+## Problem
+
+`normalizeSMSTemplate()` output is not just an in-memory value — it is persisted as the
+**identity** of every pattern:
+
+- `src/utils/pattern/normalize-sms-template.ts` — the normalizer and the exported
+  `NORMALIZER_VERSION` constant (currently `2`; nothing reads it yet).
+- `src/services/database/patterns-repository.ts` → `upsertPatternsByGrouping()` — a pattern
+  row's `name` is `murmurHash32(groupingTemplate)`. Upserts conflict-resolve on `name`.
+- `src/utils/mmkv/pattern-samples.ts` — review samples are stored in MMKV **keyed by that
+  same name hash**.
+- `src/services/sms-parsing/sms-sync-service.ts` — every sync normalizes incoming SMS with
+  the _current_ code and compares against stored `groupingPattern` strings via Dice
+  similarity ≥ 0.8 (`matchPattern`), for both active (extract) and rejected (suppress) patterns.
+
+Consequently, any change to the normalization rules makes newly normalized strings diverge
+from what is stored. Observed failure modes:
+
+1. **Duplicate patterns** — same SMS format hashes to a new `name`, so discovery inserts a
+   fresh row instead of updating the existing one. Old approved/needs-review rows are orphaned.
+2. **Rejected patterns resurface** — suppression relies on the stored rejected
+   `groupingPattern` still Dice-matching newly normalized messages. Large rule changes break
+   this (the bug class fixed in PR #46).
+3. **Orphaned MMKV samples** — samples keyed under the old hash are unreachable from the
+   new row.
+
+The v1 → v2 bump (whole-digit-run amounts, wrapped `RX_NUM` alternation so dates/bare numbers
+get `<DATE>`/`<NUM>`, `VPA` added to PROTECTED) shipped during closed beta on a
+**clean-state basis**: users clear app data via the in-app option. That is not acceptable
+after launch. This spec adds the machinery so future bumps (e.g. new placeholders such as a
+transaction-type tag) are safe, versioned migrations.
+
+## Design
+
+### 1. Schema
+
+Add to the `patterns` table in `src/db/schema.ts`:
+
+```
+normalizerVersion: integer('normalizer_version').notNull().default(2)
+```
+
+Default = the `NORMALIZER_VERSION` live when the column ships. Run `pnpm db:generate` to
+produce the Drizzle migration. Follow the repo convention: no enums, plain const maps.
+
+### 2. Stamp on write
+
+Every write of `groupingPattern` also writes `normalizerVersion: NORMALIZER_VERSION`:
+
+- `upsertPatternsByGrouping()` — both the insert values and the `onConflictDoUpdate` set.
+- Any other writer of `groupingPattern` (grep before assuming there are none).
+
+`extractionPattern` writes (`updatePatternTemplateByName`) do **not** restamp — extraction
+templates are built from raw SMS bodies and are independent of the normalizer.
+
+### 3. Recompute on upgrade
+
+Hook: after Drizzle migrations complete in `src/app/_layout.tsx` (or a service it calls),
+run `recomputeStaleGroupingPatterns()` when
+`SELECT min(normalizer_version) FROM patterns` < `NORMALIZER_VERSION`. The version check
+itself makes the routine idempotent — no separate "has run" flag needed, and a crash midway
+resumes correctly because already-updated rows are stamped.
+
+Algorithm, inside one transaction, for each row with `normalizerVersion < NORMALIZER_VERSION`:
+
+1. **Load source bodies**: MMKV samples via `getPatternSamplesByName(row.name)` — each
+   sample carries the original SMS `body`.
+2. **No samples available** (MMKV wiped, edge case):
+   - `needs-review` rows: delete — they are junk without samples and rediscoverable.
+   - approved/rejected rows: leave untouched (unstamped), log a warning with the pattern id.
+     Dice matching usually still works; the next re-approval restamps naturally.
+3. **Re-normalize** each sample body with the current `normalizeSMSTemplate`; take the
+   majority string (samples of one pattern should agree; if they tie, take the first).
+4. `newName = murmurHash32(newTemplate)`.
+5. **No collision** (no other row named `newName`): update the row's `name`,
+   `groupingPattern`, `normalizerVersion`, `updatedAt`; move MMKV samples from the old key
+   to `newName` (write new key, delete old).
+6. **Collision** (another row already has `newName` — two old formats now normalize
+   identically): merge into the surviving row:
+   - Status: if statuses differ, keep the row with the **latest `updatedAt`** (most recent
+     user decision wins — matters when approved and rejected collide); log the conflict.
+   - `usageCount`: sum. `createdAt`: earliest.
+   - MMKV samples: union, capped at 3 (`SAMPLES_PER_PATTERN` in
+     `pattern-discovery-service.ts`), keyed under `newName`; delete both old keys.
+   - `patternSmsGroup` rows (check the FK — it references pattern **id**, so renames are
+     free; merges must repoint the losing pattern's rows to the surviving id, then dedupe).
+   - Delete the losing row.
+7. Stamp `normalizerVersion = NORMALIZER_VERSION` on the surviving row.
+
+### 4. Non-goals
+
+- Changing normalization rules themselves.
+- Re-normalizing the residual SMS queue (`smsMessages`) — queue rows store raw bodies and
+  are re-normalized on every sync already.
+- Any UI. This is silent startup work; at most a log line with counts.
+
+## Tests
+
+Unit-test the recompute routine directly (repositories mocked or against an in-memory
+SQLite as other repo tests do):
+
+1. Stale row + samples → renamed, restamped, MMKV re-keyed; a subsequent discovery run
+   upserts into the same row (no duplicate).
+2. Two stale rows whose samples now normalize identically → merged; latest-`updatedAt`
+   status survives; usage summed; one MMKV key with ≤ 3 samples.
+3. Approved-vs-rejected collision → latest decision wins, warning logged.
+4. Stale `needs-review` row without samples → deleted; approved row without samples →
+   untouched and unstamped.
+5. Routine is a no-op when all rows are current (and safe to run twice).
+6. Fixture realism: build "old" rows by hand-writing v1-style strings (e.g.
+   `<CUR><AMT>00.00` truncation artifacts) so the test does not depend on old code.
+
+## Acceptance criteria
+
+- [ ] `patterns.normalizerVersion` column exists; all `groupingPattern` writers stamp it.
+- [ ] Startup recompute runs only when stale rows exist; idempotent; single transaction.
+- [ ] Renames preserve MMKV samples and `patternSmsGroup` links.
+- [ ] Collisions merge with latest-decision-wins status policy, logged.
+- [ ] All tests above pass; `pnpm test`, `pnpm type-check`, `pnpm lint` clean.
+- [ ] A future `NORMALIZER_VERSION` bump requires **no data clearing** — verify by bumping
+      the constant in a test and asserting stored patterns keep matching after recompute.

--- a/src/services/sms-parsing/pattern-discovery-service.spec.ts
+++ b/src/services/sms-parsing/pattern-discovery-service.spec.ts
@@ -70,6 +70,32 @@ describe('PatternDiscoveryService', () => {
     expect(mockSetSamples).toHaveBeenCalledWith(murmurHash32(upiDraft.groupingTemplate), upiDraft.transactions)
   })
 
+  it('reconciles a bootstrap miss from the group consensus', async () => {
+    const bodies = [
+      'Rs.120.00 paid at STORE via UPI on 10-07-26. Avl Bal Rs.4,000.00',
+      'Rs.240.00 paid at BAKERY via UPI on 11-07-26. Avl Bal Rs.3,760.00',
+      // digit-leading name: the rule-based bootstrap cannot capture this merchant
+      'Rs.75.00 paid at 24SEVEN via UPI on 12-07-26. Avl Bal Rs.3,685.00',
+    ]
+    mockSync.mockResolvedValue({
+      extracted: [],
+      candidates: bodies.map(makeCandidate),
+      ignored: 0,
+      totalRead: bodies.length,
+    })
+
+    const result = await PatternDiscoveryService.discoverFromLastNDays(60)
+
+    expect(result.patternsFound).toBe(1)
+    const [draft] = mockUpsert.mock.calls[0][0]
+    expect(draft.transactions.map((t: { amount: number }) => t.amount)).toEqual([120, 240, 75])
+    expect(draft.transactions.map((t: { merchantRaw: string }) => t.merchantRaw)).toEqual([
+      'STORE',
+      'BAKERY',
+      '24SEVEN',
+    ])
+  })
+
   it('skips candidates where the parser finds no amount', async () => {
     mockSync.mockResolvedValue({
       extracted: [],

--- a/src/services/sms-parsing/pattern-discovery-service.ts
+++ b/src/services/sms-parsing/pattern-discovery-service.ts
@@ -6,7 +6,7 @@ import { murmurHash32 } from '@/utils/hash/murmur32'
 import { setPatternSamplesByName } from '@/utils/mmkv/pattern-samples'
 import { groupByTemplate } from '@/utils/pattern/group-by-template'
 import { mergeSimilarGroups } from '@/utils/pattern/merge-similar-groups'
-import { proposeSlots } from '@/utils/pattern/propose-slots'
+import { reconcileGroupSamples } from '@/utils/pattern/reconcile-group-samples'
 import { SMSDataExtractor } from './sms-data-extractor-service'
 import { SMSReaderService } from './sms-reader-service'
 import { SmsSyncService, type CandidateSms } from './sms-sync-service'
@@ -20,8 +20,9 @@ interface CandidateSample {
 
 /**
  * Batch discovery: turn unmatched transaction-candidates into needs-review
- * pattern drafts. The parser library bootstraps amount/merchant so review
- * shows pre-filled guesses instead of blank slots.
+ * pattern drafts. The rule-based extractor bootstraps amount/merchant per
+ * message, then each group's guesses are reconciled against the consensus
+ * template so review shows consistent pre-fills instead of one-off misreads.
  */
 export class PatternDiscoveryService {
   static async discoverFromLastNDays(days: number): Promise<{ patternsFound: number }> {
@@ -56,15 +57,14 @@ export class PatternDiscoveryService {
     )
 
     const drafts: DistinctPattern[] = groups.map((group, index) => {
-      const first = group.items[0].transaction
-      const { template } = proposeSlots(first.body, first.amount, first.merchantRaw || undefined)
+      const { template, samples: transactions } = reconcileGroupSamples(group.items.map((s) => s.transaction))
 
       return {
         id: String(index + 1),
         template,
         groupingTemplate: group.groupingPattern,
         occurrences: group.items.length,
-        transactions: group.items.map((s) => s.transaction),
+        transactions,
         patternType: TRANSACTION_TYPE.Debit, // v1: only debit
         status: PATTERN_STATUS.NeedsReview,
       }

--- a/src/services/sms-parsing/sms-data-extractor-service.spec.ts
+++ b/src/services/sms-parsing/sms-data-extractor-service.spec.ts
@@ -16,8 +16,7 @@ describe('SMSDataExtractorService', () => {
     expect(res.intent).toBe('expense')
     expect(res.amount?.value).toBe(1250)
     expect(res.amount?.currency).toBe('INR')
-    // merchant neighbor by "at"
-    // expect(res.merchant).toBe('SWIGGY') // TODO: uncomment this
+    expect(res.merchant).toBe('SWIGGY')
     // bank heuristics absent here (no bank word), may be undefined
     expect(res.bank?.name === 'SBI' || res.bank === undefined).toBe(true)
     expect(res.datetimeText).toBeDefined()
@@ -30,7 +29,41 @@ describe('SMSDataExtractorService', () => {
     expect(res.isTransaction).toBe(true)
     expect(res.intent).toBe('income')
     expect(res.amount?.value).toBe(5000)
-    // expect(res.merchant).toBe('EMPLOYER') // TODO: uncomment this
+    expect(res.merchant).toBe('EMPLOYER')
+  })
+
+  it('captures multi-word merchants after case-insensitive cues', () => {
+    const sms = 'Sent Rs.60.00 From HDFC Bank A/C x1234 To PhonePe Merchant On 12/04 Ref 106122334455'
+    const res = SMSDataExtractor.extract(sms, 'expense')
+    expect(res.amount?.value).toBe(60)
+    expect(res.merchant).toBe('PhonePe Merchant')
+  })
+
+  it('does not return the bank itself as merchant', () => {
+    const sms = 'Rs 500 debited from HDFC Bank account. Avl bal Rs 2,000'
+    const res = SMSDataExtractor.extract(sms, 'expense')
+    expect(res.amount?.value).toBe(500)
+    expect(res.merchant).toBeUndefined()
+  })
+
+  it('captures a VPA named after a cue', () => {
+    const sms = 'Paid Rs.180.00 to swiggy8@ybl via UPI. Ref no 456712349876.'
+    const res = SMSDataExtractor.extract(sms, 'expense')
+    expect(res.amount?.value).toBe(180)
+    expect(res.merchant).toBe('swiggy8@ybl')
+  })
+
+  it('falls back to a VPA anywhere in the body when no cue captures a name', () => {
+    const sms = 'Rs.299 debited from A/c XX4321 for UPI to VPA netflix.upi@icici on 10-07-26. Avl Bal Rs.8,000'
+    const res = SMSDataExtractor.extract(sms, 'expense')
+    expect(res.amount?.value).toBe(299)
+    expect(res.merchant).toBe('netflix.upi@icici')
+  })
+
+  it('does not treat bank support e-mails as VPAs', () => {
+    const sms = 'Rs 120 debited. Avl bal Rs 900. Queries? Write to care@hdfcbank.com'
+    const res = SMSDataExtractor.extract(sms, 'expense')
+    expect(res.merchant).toBeUndefined()
   })
 
   it('prefers verb-proximal amount over balance amount', () => {
@@ -60,6 +93,7 @@ describe('SMSDataExtractorService', () => {
       ['Paid ₹750 to ABC', 750],
       ['debited by 60.0 at XYZ', 60],
       ['received 1,234 from John', 1234],
+      ['1,234 INR sent to Mark', 1234],
     ] as const
 
     for (const [text, expected] of cases) {

--- a/src/services/sms-parsing/sms-data-extractor-service.ts
+++ b/src/services/sms-parsing/sms-data-extractor-service.ts
@@ -43,19 +43,84 @@ export class SMSDataExtractorService {
     'au small finance',
   ]
 
-  // core regex
+  // Numbers accept Indian comma grouping ("1,23,456") or plain digit runs ("10000") —
+  // requiring the comma branch to have at least one group keeps plain runs whole.
   private RX_AMOUNT =
-    /(?:(?:inr|rs\.?|₹)\s*)\d{1,3}(?:,\d{2,3})*(?:\.\d+)?|\b\d+(?:\.\d+)?\s*(?:inr|rs)\b|(?:debited|credited|paid|received|transferred|spent|withdrawn|deposited)\s+(?:by|of|for|to|from)?\s*(\d{1,3}(?:,\d{2,3})*(?:\.\d+)?)/gi
-  private RX_ANYNUM = /\d{1,3}(?:,\d{2,3})*(?:\.\d+)?/
+    /(?:(?:inr|rs\.?|₹)\s*)(?:\d{1,3}(?:,\d{2,3})+|\d+)(?:\.\d+)?|\b(?:\d{1,3}(?:,\d{2,3})+|\d+)(?:\.\d+)?\s*(?:inr|rs)\b|(?:debited|credited|paid|received|transferred|spent|withdrawn|deposited)\s+(?:by|of|for|to|from)?\s*((?:\d{1,3}(?:,\d{2,3})+|\d+)(?:\.\d+)?)/gi
+  private RX_ANYNUM = /(?:\d{1,3}(?:,\d{2,3})+|\d+)(?:\.\d+)?/
   private RX_BALANCE_CUE = /\b(avl\.?\s*bal|available\s*balance|ledger\s*balance|bal\.?)\b/i
   private RX_UTR_RRN = /\b[0-9A-Z]{10,22}\b/g
   private RX_DATETIME =
     /\b(?:\d{1,2}[:.]\d{2}\s?(?:am|pm)?)|(?:\d{1,2}[\/\-][A-Za-z]{3,9}[\/\-]?\d{0,4})|(?:\d{1,2}[\/\-]\d{1,2}[\/\-]\d{2,4})|(?:\b(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\b\.?\s?\d{1,2}(?:,\s?\d{2,4})?)/gi
-  private RX_VPA = /\b[a-z0-9._-]{2,}@[a-z]{2,}\b/i // internal only
+  // Lowercase-only: banks print VPAs in lowercase, and this keeps uppercase Info-blob prefixes
+  // ("ICCL ZERODHA COIN-zerodhamf@hdfcbank") out of the handle; the alphanumeric first char
+  // stops a leading blob dash from joining. Trailing (?!\.[a-z]) rejects e-mail domains
+  // ("care@hdfcbank.com") while keeping VPAs at sentence end.
+  private RX_VPA = /\b[a-z0-9][a-z0-9._-]+@[a-z]{2,}\b(?!\.[a-z])/
   private RX_LAST4 = /(?:\*{2,}|x{2,})\s?(\d{3,6})\b|\b(\d{4})\b/gi // internal only
 
   private VERBS_DEBIT = /\b(debited|paid|spent|withdrawn|purchased?|sent|transferred|charged)\b/i
-  private VERBS_CREDIT = /\b(credited|received|reversed|refund(?:ed)?)\b/i
+  private VERBS_CREDIT = /\b(credited|received|deposited|reversed|refund(?:ed)?)\b/i
+
+  private RX_MERCH_CUE = /\b(?:at|to|from)\s+/gi
+  private RX_MASKED_ACCOUNT = /^x+\d/i
+  // Tokens that end a merchant name: what follows a name in bank SMS, never part of one.
+  private MERCHANT_STOP = new Set([
+    'on',
+    'via',
+    'ref',
+    'refno',
+    'txn',
+    'upi',
+    'vpa',
+    'avl',
+    'bal',
+    'balance',
+    'available',
+    'ledger',
+    'ac',
+    'acct',
+    'account',
+    'card',
+    'info',
+    'not',
+    'is',
+    'was',
+    'has',
+    'your',
+    'please',
+    'sms',
+    'call',
+    'dial',
+    'block',
+    'and',
+    'or',
+    'the',
+    'of',
+    'by',
+    'from',
+    'to',
+    'at',
+    'for',
+    'rs',
+    'inr',
+    'dated',
+    'dt',
+    'id',
+    'no',
+    'mobile',
+    'number',
+    'customer',
+    'helpline',
+    'linked',
+    'using',
+    'dispute',
+    'clearing',
+  ])
+  // A cue preceded by call-to-action context ("Call 1800... to report") is boilerplate, not a payee.
+  private RX_CTA_CONTEXT = /call|sms|dial|click|visit|quer|dispute/i
+  // Channel words that are valid inside a name ("HDFC ATM MG ROAD") but meaningless alone.
+  private MERCHANT_NOISE = new Set(['atm', 'upi', 'imps', 'neft', 'rtgs', 'pos', 'netbanking', 'card'])
 
   private toNumber = (s: string) => {
     const v = Number(s.replace(/,/g, ''))
@@ -64,7 +129,64 @@ export class SMSDataExtractorService {
   private pickCurrency = (s: string) => (/₹|inr|rs\b/i.test(s) ? 'INR' : 'INR')
   private windowHas = (hay: string, idx: number, rx: RegExp) =>
     rx.test(hay.slice(Math.max(0, idx - 30), Math.min(hay.length, idx + 30))) ? 1 : 0
-  private neighborName = (text: string) => text.match(/\b(?:at|to|from)\s+([A-Z][A-Za-z0-9 &._-]{2,})/)?.[1]?.trim()
+
+  /**
+   * Read a merchant-name run starting at `start`: word tokens up to a stop token,
+   * a slash/masked-account token, a digit-leading token (dates, refs), or trailing
+   * punctuation. Leading punctuation on the first token is skipped ("+MALL", "..STORE").
+   * Returns the verbatim slice so callers can locate it in the body.
+   */
+  private captureNameAt(raw: string, start: number): string | undefined {
+    const rx = /\S+/g
+    rx.lastIndex = start
+    let nameStart = -1
+    let end = -1
+    for (let count = 0; count < 5; count += 1) {
+      const match = rx.exec(raw)
+      if (!match) break
+      const token = match[0]
+      let word = token.replace(/[.,;:!?)'"]+$/, '')
+      let offset = 0
+      if (count === 0) {
+        offset = (word.match(/^[^A-Za-z0-9]+/)?.[0] ?? '').length
+        word = word.slice(offset)
+      }
+      const tildeAt = word.indexOf('~') // tilde-delimited formats fuse the next field onto the name
+      if (tildeAt !== -1) word = word.slice(0, tildeAt)
+      if (!word || !/^[A-Za-z]/.test(word) || word.includes('/')) break
+      if (this.RX_MASKED_ACCOUNT.test(word) || this.MERCHANT_STOP.has(word.toLowerCase())) break
+      if (nameStart === -1) nameStart = match.index + offset
+      end = match.index + offset + word.length
+      if (offset + word.length !== token.length) break // token was cut short: the name ends here
+    }
+    if (end === -1) return undefined
+    const name = raw.slice(nameStart, end).trim()
+    return name.length >= 2 ? name : undefined
+  }
+
+  /**
+   * Merchant = the name after the at/to/from cue closest to the transaction amount,
+   * skipping bank self-references and call-to-action tails; falls back to a UPI VPA
+   * anywhere in the body.
+   */
+  private findMerchant(raw: string, amountIdx: number): string | undefined {
+    const candidates: { name: string; index: number }[] = []
+    for (const cue of raw.matchAll(this.RX_MERCH_CUE)) {
+      const cueStart = cue.index ?? 0
+      if (this.RX_CTA_CONTEXT.test(raw.slice(Math.max(0, cueStart - 25), cueStart))) continue
+      const start = cueStart + cue[0].length
+      const name = this.captureNameAt(raw, start)
+      if (!name) continue
+      const lower = name.toLowerCase()
+      if (lower.includes('bank') || this.BANK_WORDS.includes(lower) || this.MERCHANT_NOISE.has(lower)) continue
+      candidates.push({ name, index: start })
+    }
+    if (candidates.length > 0) {
+      candidates.sort((a, b) => Math.abs(a.index - amountIdx) - Math.abs(b.index - amountIdx))
+      return candidates[0].name
+    }
+    return raw.match(this.RX_VPA)?.[0] ?? undefined
+  }
 
   extract(rawText: string, intent: Intent): TxnFields {
     const raw = String(rawText ?? '')
@@ -98,7 +220,6 @@ export class SMSDataExtractorService {
     const refs = Array.from(raw.matchAll(this.RX_UTR_RRN), (m) => m[0]).filter((x) => x.length >= 12)
     const bank = this.BANK_WORDS.find((b) => lower.includes(b))
     const datetime = raw.match(this.RX_DATETIME)?.[0] || undefined
-    const merchant = this.neighborName(raw)
 
     // pick transaction amount (verb proximity beats balance cues)
     let bestAmt = amounts[0]
@@ -113,6 +234,8 @@ export class SMSDataExtractorService {
         bestAmt = a
       }
     }
+
+    const merchant = this.findMerchant(raw, bestAmt?.start ?? 0)
 
     const amountField = bestAmt && {
       value: bestAmt.value,

--- a/src/services/sms-parsing/sms-extraction-corpus.spec.ts
+++ b/src/services/sms-parsing/sms-extraction-corpus.spec.ts
@@ -1,0 +1,208 @@
+import { TRANSACTION_TYPE, type TransactionType } from '@/db/schema'
+import { isTransactionCandidate } from '@/utils/pattern/is-transaction-candidate'
+import { SMSDataExtractor } from './sms-data-extractor-service'
+
+/**
+ * Real-world corpus: one entry per SMS format family observed in an actual inbox
+ * export (ICICIT / HDFCBK / SBIUPI senders). Bodies are verbatim except that
+ * account tails, reference numbers, phone numbers, person names, employers and
+ * localities are cooked-up. Amount/merchant expectations describe the bootstrap
+ * extractor's contract for the pattern-review pre-fill.
+ */
+
+interface TxnEntry {
+  label: string
+  body: string
+  type: TransactionType
+  amount: number
+  merchant: string | undefined
+}
+
+const TRANSACTIONS: TxnEntry[] = [
+  {
+    label: 'hdfc upi sent to person',
+    body: 'Amt Sent Rs.1065.00 From HDFC Bank A/C *5432 To SENTHIL K On 14-02 Ref 543210987654 Not You? Call 54321098765/SMS BLOCK UPI to 5432109876',
+    type: TRANSACTION_TYPE.Debit,
+    amount: 1065,
+    merchant: 'SENTHIL K',
+  },
+  {
+    label: 'sbi upi transfer, amount without currency marker',
+    body: 'Dear UPI user A/C X5432 debited by 50.0 on date 05May24 trf to Mr Arun Prakash Refno 543210987654. If not u? call 5432109876. -SBI',
+    type: TRANSACTION_TYPE.Debit,
+    amount: 50,
+    merchant: 'Mr Arun Prakash',
+  },
+  {
+    label: 'icici credit card spend with Avl Lmt tail',
+    body: 'INR 920.00 spent on ICICI Bank Card XX5432 on 13-Oct-23 at IND*Amazon.in -. Avl Lmt: INR 2,63,617.00. To dispute,call 18002662/SMS BLOCK 4321 to 5432109876',
+    type: TRANSACTION_TYPE.Debit,
+    amount: 920,
+    merchant: 'IND*Amazon.in',
+  },
+  {
+    label: 'hdfc atm withdrawal with comma-fused location',
+    body: "ALERT:You've withdrawn Rs.10000.00 via Debit Card xx5432 at ANNA NGR,PORUR on 2018-11-26:08:57:30.Avl Bal Rs.38984.96.Not you?Call 54321098765.",
+    type: TRANSACTION_TYPE.Debit,
+    amount: 10000,
+    merchant: 'ANNA NGR,PORUR',
+  },
+  {
+    label: 'hdfc money transfer to lowercase upi handle',
+    body: 'Money Transfer:Rs 500.00 from HDFC Bank A/c **5432 on 03-09-23 to kmstores UPI: 543210987654 Not you? Call 54321098765',
+    type: TRANSACTION_TYPE.Debit,
+    amount: 500,
+    merchant: 'kmstores',
+  },
+  {
+    label: 'hdfc upi debit to biller vpa, cta tail "to report"',
+    body: 'Rs 589.00 debited from a/c **5432 on 29-05-19 to VPA billdesk.airtel-postpaid@icici(UPI Ref No 543210987654). Not you? Call on 54321098765 to report',
+    type: TRANSACTION_TYPE.Debit,
+    amount: 589,
+    merchant: 'billdesk.airtel-postpaid@icici',
+  },
+  {
+    label: 'hdfc card spend with five-word merchant',
+    body: 'Rs.500 spent on HDFC Bank Card x5432 at BPCL ASM FUEL POINT A on 2024-01-31:17:24:52 Avl bal: 1269999.05.Not You? Call 54321098765 / SMS BLOCK DC 4321 to 5432109876',
+    type: TRANSACTION_TYPE.Debit,
+    amount: 500,
+    merchant: 'BPCL ASM FUEL POINT A',
+  },
+  {
+    label: 'hdfc netbanking payment ("Thanks for paying")',
+    body: 'Thanks for paying Rs.949.76 from A/c XXXX5432 to CCAGodaddyIndiaDomai via NetBanking. Call 54321098765 if txn not done by you',
+    type: TRANSACTION_TYPE.Debit,
+    amount: 949.76,
+    merchant: 'CCAGodaddyIndiaDomai',
+  },
+  {
+    label: 'hdfc debit card store spend ("Thank you for using")',
+    body: 'Thank you for using Debit Card ending 4321 for Rs.141.00 in CHENNAI at SARAVANA STORES TEX on 2018-06-02:14:32:56 Avl bal: Rs.134284.11',
+    type: TRANSACTION_TYPE.Debit,
+    amount: 141,
+    merchant: 'SARAVANA STORES TEX',
+  },
+  {
+    label: 'hdfc emi debit with Info blob, no merchant',
+    body: 'UPDATE: INR 6,627.00 debited from A/c XX5432 on 05-NOV-18. Info: EMI 30754321 Chq S54321098765 543210987654. Avl bal:INR 7,072.46',
+    type: TRANSACTION_TYPE.Debit,
+    amount: 6627,
+    merchant: undefined,
+  },
+  {
+    label: 'hdfc upi debit with vpa inside Info blob',
+    body: 'UPDATE: INR 10,000.00 debited from HDFC Bank XX5432 on 03-FEB-23. Info: UPI-ICCL ZERODHA COIN-zerodhamf@hdfcbank-HDFC0000060-543210987654-oRUjhAaDEfuHdyvAHO. Avl bal:INR 9,87,950.72',
+    type: TRANSACTION_TYPE.Debit,
+    amount: 10000,
+    merchant: 'zerodhamf@hdfcbank',
+  },
+  {
+    label: 'hdfc netbanking payment successful',
+    body: 'Payment Successful! Rs. 50000.00 from A/c **********5432 to RAZPBSEINDIACOM via HDFC Bank NetBanking. Not you?Call 54321098765',
+    type: TRANSACTION_TYPE.Debit,
+    amount: 50000,
+    merchant: 'RAZPBSEINDIACOM',
+  },
+  {
+    label: 'hdfc account-to-account transfer, no merchant',
+    body: 'Rs. 49345.00 debited from a/c **5432 on 18-05-19 to a/c **5432 (UPI Ref No. 543210987654). Not you? Call on 54321098765 to report',
+    type: TRANSACTION_TYPE.Debit,
+    amount: 49345,
+    merchant: undefined,
+  },
+  {
+    label: 'hdfc upi credit from vpa',
+    body: 'Rs. 200.00 credited to a/c XXXXXX5432 on 12-06-19 by a/c linked to VPA arunstores@okhdfcbank (UPI Ref No 543210987654).',
+    type: TRANSACTION_TYPE.Credit,
+    amount: 200,
+    merchant: 'arunstores@okhdfcbank',
+  },
+  {
+    label: 'sbi upi credit from person',
+    body: 'Dear SBI User, your A/c X5432-credited by Rs.99 on 14Aug24 transfer from PRAVEEN R Ref No 543210987654 -SBI',
+    type: TRANSACTION_TYPE.Credit,
+    amount: 99,
+    merchant: 'PRAVEEN R',
+  },
+  {
+    label: 'hdfc salary deposit with NEFT blob',
+    body: 'Update! INR 1,72,393.00 deposited in HDFC Bank A/c XX5432 on 29-SEP-23 for NEFT Cr-SCBL0036001-ACME ANALYTICS PRIVATE LIMITED-Ramesh Kumar-IN1ON2309290B8F6.Avl bal INR 11,41,678.60. Cheque deposits in A/C are subject to clearing',
+    type: TRANSACTION_TYPE.Credit,
+    amount: 172393,
+    merchant: undefined,
+  },
+  {
+    label: 'hdfc imps credit from mobile-linked account',
+    body: 'UPDATE: Your A/c XX5432 credited with INR 25,300.00 on 14-11-18 by A/c linked to mobile no XX5432 (IMPS Ref No. 543210987654) Available bal: INR 31,757.46',
+    type: TRANSACTION_TYPE.Credit,
+    amount: 25300,
+    merchant: undefined,
+  },
+  {
+    label: 'hdfc credit alert from phone-number vpa',
+    body: 'Credit Alert! Rs.250.00 credited to HDFC Bank A/c xx5432 on 13-02-25 from VPA 5432109876@axl (UPI 543210987654)',
+    type: TRANSACTION_TYPE.Credit,
+    amount: 250,
+    merchant: '5432109876@axl',
+  },
+  {
+    label: 'hdfc rtgs deposit, tilde-delimited fields',
+    body: 'RTGS Money Deposited~INR 4,12,000.00~To Ravi~Txn No: HDFCR54321098765432109~On 01-09-2025 at 21:56:01~-HDFC Bank',
+    type: TRANSACTION_TYPE.Credit,
+    amount: 412000,
+    merchant: 'Ravi',
+  },
+  {
+    label: 'icici credit card payment received',
+    body: 'Payment of Rs 32,948.16 has been received on your ICICI Bank Credit Card XX5432 through Bharat Bill Payment System on 13-MAR-25.',
+    type: TRANSACTION_TYPE.Credit,
+    amount: 32948.16,
+    merchant: undefined,
+  },
+]
+
+const NON_TRANSACTIONS: { label: string; body: string }[] = [
+  {
+    label: 'upi collect request',
+    body: 'Indiaideas has requested Rs. 399.00 from you through UPI. To authorize debit from your account please login to your UPI App. To pay instantly click here http://bit.ly/2Qh8kh4',
+  },
+  {
+    label: 'google pay collect request',
+    body: 'Amazon India has requested Rs548.27 frm u on Google Pay app. Once approved, money will be debited frm ur a/c -SBI',
+  },
+  {
+    label: 'credit card due reminder',
+    body: 'Pay Total Amount Due of Rs 27,491.45 or Minimum Amount Due of Rs 1,380.00 by 30-May-26 towards ICICI Bank Credit Card XX5432. Delay/Non-payment is reported to Credit Bureaus. Ignore if paid.',
+  },
+  {
+    label: 'emi due reminder',
+    body: 'Alert: EMI of Rs. 44835 is due on 07-Apr-2026, for HDFC Bank Loan A/c 543210987. Please ensure sufficient balance to avoid bounce and delayed interest charges.',
+  },
+  {
+    label: 'reversal of unsuccessful atm withdrawal',
+    body: 'Your unsuccessful ATM WDL txn on HDFC Bank DEBIT/ATM Card ending 4321 of Rs. 50000.00 at location +MADIPAKKAM OATM on 2019-05-18:13:45:20 is reversed to A/c. Regret inconvenience.',
+  },
+  {
+    label: 'otp with amount in body',
+    body: '892 is your OTP to increase HDFC Bank Fund Transfer Limit to Rs.4,000,000.00 Ref No.XXXX5432 NEVER share OTP',
+  },
+  {
+    label: 'declined card transaction',
+    body: 'TXN DECLINED: Rs.150.00 on 23-06-26 at 22:57 on HDFC Bank Debit Card xx5432. Reason: Online Usage disabled. Enable it:https://1.hdfc.bank.in/HDFCBK/a/14AjOHa',
+  },
+]
+
+describe('SMS extraction corpus (anonymized real formats)', () => {
+  it.each(TRANSACTIONS)('$label', (entry) => {
+    expect(isTransactionCandidate(entry.body)).toBe(entry.type)
+
+    const intent = entry.type === TRANSACTION_TYPE.Credit ? 'income' : 'expense'
+    const fields = SMSDataExtractor.extract(entry.body, intent)
+    expect(fields.amount?.value).toBe(entry.amount)
+    expect(fields.merchant).toBe(entry.merchant)
+  })
+
+  it.each(NON_TRANSACTIONS)('$label is not a transaction candidate', (entry) => {
+    expect(isTransactionCandidate(entry.body)).toBeNull()
+  })
+})

--- a/src/utils/pattern/is-transaction-candidate.ts
+++ b/src/utils/pattern/is-transaction-candidate.ts
@@ -2,9 +2,10 @@ import { TRANSACTION_TYPE, type TransactionType } from '@/db/schema'
 
 const RX_FAILURE = /\b(failed|declined|rejected|unsuccessful|could\s+not\s+be\s+processed)\b/i
 const RX_FUTURE =
-  /\b(will\s+be\s+(?:debited|credited|charged)|scheduled\s+(?:on|for)|autopay|auto[-\s]?pay|standing\s+instruction|due\s+(?:on|by)|payment\s+reminder)\b/i
-const RX_DEBIT_VERB = /\b(debited|paid|spent|purchased?|withdraw(?:n|al)|sent|transferred|charged|deducted)\b/i
-const RX_CREDIT_VERB = /\b(credited|received|refund(?:ed)?|cashback|reversed)\b/i
+  /\b(will\s+be\s+(?:debited|credited|charged)|scheduled\s+(?:on|for)|autopay|auto[-\s]?pay|standing\s+instruction|due\s+(?:on|by)|total\s+(?:amount\s+)?due|min(?:imum)?\s+(?:amount\s+)?due|payment\s+reminder)\b/i
+const RX_DEBIT_VERB =
+  /\b(debited|paid|paying|spent|purchased?|withdraw(?:n|al)|sent|transferred|charged|deducted|money\s+transfer|payment\s+successful|thank\s+you\s+for\s+using)\b/i
+const RX_CREDIT_VERB = /\b(credited|received|deposited|refund(?:ed)?|cashback|reversed)\b/i
 const RX_AMOUNT_CUE =
   /(?:₹|rs\.?|inr)\s*\d|\b\d[\d,]*(?:\.\d{1,2})?\s*(?:inr|rs)\b|\b(?:debited|credited|paid|received|charged)\s+(?:by|of|for|with)?\s*(?:₹|rs\.?|inr)?\s*\d/i
 

--- a/src/utils/pattern/normalize-sms-template.spec.ts
+++ b/src/utils/pattern/normalize-sms-template.spec.ts
@@ -1,0 +1,30 @@
+import { normalizeSMSTemplate } from './normalize-sms-template'
+
+describe('normalizeSMSTemplate', () => {
+  it('produces the same grouping template regardless of amount magnitude', () => {
+    const small = normalizeSMSTemplate('Rs.500 spent at STORE on 12-10-25. Avl bal Rs.900.00')
+    const large = normalizeSMSTemplate('Rs.10000.00 spent at STORE on 12-10-25. Avl bal Rs.38984.96')
+    expect(large).toBe(small)
+  })
+
+  it('treats comma-grouped and plain amounts identically', () => {
+    expect(normalizeSMSTemplate('Rs 1500.00 debited')).toBe(normalizeSMSTemplate('Rs 1,500.00 debited'))
+  })
+
+  it('keeps whole plain digit runs in one <CUR><AMT> tag', () => {
+    expect(normalizeSMSTemplate('Rs.10000.00 debited')).toBe('<CUR><AMT> debited')
+  })
+
+  it('tags dates and bare numbers separately from amounts', () => {
+    expect(normalizeSMSTemplate('Paid Rs.100 on 15-08-25 ref 45678')).toBe('Paid <CUR><AMT> on <DATE> ref <NUM>')
+  })
+
+  it('tags a currency-less balance after the balance cue', () => {
+    expect(normalizeSMSTemplate('debited Rs.50. Avl bal 20,000.')).toContain('<BAL_CUE> <BAL>')
+  })
+
+  it('tags VPAs, masked accounts and numeric references', () => {
+    const normalized = normalizeSMSTemplate('Rs.250 debited from a/c **1234 to VPA swiggy@icici UPI Ref 987654321098')
+    expect(normalized).toBe('<CUR><AMT> debited from a/c <LAST4> to VPA <VPA> UPI Ref <REF>')
+  })
+})

--- a/src/utils/pattern/normalize-sms-template.ts
+++ b/src/utils/pattern/normalize-sms-template.ts
@@ -2,14 +2,39 @@
  * Bump whenever the normalization rules below change: stored grouping patterns were
  * computed with the version recorded on their row and must be recomputed to keep
  * exact-match lookups working.
+ *
+ * v2: numbers keep whole plain digit runs ("10000" no longer splits), and only
+ * currency-adjacent numbers become <CUR><AMT> — dates and bare numbers now reach
+ * their own <DATE>/<NUM> tags. Recompute machinery is not built yet (see
+ * docs/NORMALIZER_VERSIONING.md); shipped during closed beta on clean-state basis.
  */
-export const NORMALIZER_VERSION = 1
+export const NORMALIZER_VERSION = 2
 
-const PROTECTED = ['UPI', 'IMPS', 'NEFT', 'RTGS', 'POS', 'ATM', 'NETBANKING', 'OTP', 'EMI', 'SI', 'AUTO-PAY', 'AUTOPAY']
+const PROTECTED = [
+  'UPI',
+  'VPA',
+  'IMPS',
+  'NEFT',
+  'RTGS',
+  'POS',
+  'ATM',
+  'NETBANKING',
+  'OTP',
+  'EMI',
+  'SI',
+  'AUTO-PAY',
+  'AUTOPAY',
+]
 
 const RX_CUR = /(?:₹|rs\.?|inr)/i
-const RX_NUM = /\d{1,3}(?:,\d{2,3})*(?:\.\d+)?|\d+(?:\.\d+)?/ // Indian + generic
-const RX_AMOUNT = new RegExp(`(?:${RX_CUR.source})\\s*${RX_NUM.source}|${RX_NUM.source}\\s*(?:${RX_CUR.source})`, 'gi')
+// Indian comma grouping (at least one group) or a whole plain run — never a 3-digit prefix.
+const RX_NUM = /\d{1,3}(?:,\d{2,3})+(?:\.\d+)?|\d+(?:\.\d+)?/
+// RX_NUM is an alternation, so interpolations must be wrapped — unwrapped, its second
+// branch becomes a top-level alternative that tags every bare number as an amount.
+const RX_AMOUNT = new RegExp(
+  `(?:${RX_CUR.source})\\s*(?:${RX_NUM.source})|(?:${RX_NUM.source})\\s*(?:${RX_CUR.source})`,
+  'gi'
+)
 
 const RX_BAL_CUE = /\b(avl\.?\s*bal|available\s*balance|ledger\s*balance|bal\.?)\b/gi
 const RX_VPA = /\b[a-z0-9._-]{2,}@[a-z]{2,}\b/gi
@@ -55,7 +80,7 @@ export function normalizeSMSTemplate(sms: string): string {
   // 5) Balance numbers right after the cue
   //    Replace "<BAL_CUE> ... <NUM>" → "<BAL_CUE> <CUR><BAL>" or "<BAL>"
   s = s.replace(
-    /<BAL_CUE>\s*(?:<CUR>)?\s*(?:<AMT>|(\d{1,3}(?:,\d{2,3})*(?:\.\d+)?|\d+(?:\.\d+)?))/gi,
+    /<BAL_CUE>\s*(?:<CUR>)?\s*(?:<AMT>|(\d{1,3}(?:,\d{2,3})+(?:\.\d+)?|\d+(?:\.\d+)?))/gi,
     (_m, numOnly) => `<BAL_CUE> ${/^\d/.test(String(numOnly)) ? '<BAL>' : '<CUR><BAL>'}`
   )
 
@@ -79,7 +104,7 @@ export function normalizeSMSTemplate(sms: string): string {
   s = s.replace(RX_DATE, '<DATE>')
 
   // 10) Collapse leftover pure numbers that aren’t already tagged → <NUM>
-  s = s.replace(/\b\d{1,3}(?:,\d{2,3})*(?:\.\d+)?\b/g, '<NUM>')
+  s = s.replace(/\b(?:\d{1,3}(?:,\d{2,3})+|\d+)(?:\.\d+)?\b/g, '<NUM>')
 
   // 11) Normalize spaces/punctuation
   s = s

--- a/src/utils/pattern/reconcile-group-samples.spec.ts
+++ b/src/utils/pattern/reconcile-group-samples.spec.ts
@@ -1,0 +1,74 @@
+import { reconcileGroupSamples } from './reconcile-group-samples'
+
+function sample(body: string, amount: number, merchantRaw = '') {
+  return { body, amount, merchantRaw }
+}
+
+describe('reconcileGroupSamples', () => {
+  it('outvotes a minority wrong amount with the consensus template', () => {
+    const samples = [
+      sample('Rs.100.00 paid to AMAZON via UPI. Avl Bal Rs.900.00', 100, 'AMAZON'),
+      sample('Rs.250.00 paid to FLIPKART via UPI. Avl Bal Rs.650.00', 250, 'FLIPKART'),
+      // bootstrap mistakenly picked the balance for this one
+      sample('Rs.75.00 paid to SWIGGY via UPI. Avl Bal Rs.575.00', 575, 'SWIGGY'),
+    ]
+
+    const { template, samples: reconciled } = reconcileGroupSamples(samples)
+
+    expect(template).toContain('<AMT>')
+    expect(template).toContain('<MERCHANT>')
+    expect(reconciled.map((s) => s.amount)).toEqual([100, 250, 75])
+    expect(reconciled.map((s) => s.merchantRaw)).toEqual(['AMAZON', 'FLIPKART', 'SWIGGY'])
+  })
+
+  it('fills a merchant the bootstrap missed from the aligned gap', () => {
+    const samples = [
+      sample('Rs.120.00 paid at STORE via UPI on 10-07-26. Avl Bal Rs.4,000.00', 120, 'STORE'),
+      sample('Rs.240.00 paid at BAKERY via UPI on 11-07-26. Avl Bal Rs.3,760.00', 240, 'BAKERY'),
+      sample('Rs.75.00 paid at 24SEVEN via UPI on 12-07-26. Avl Bal Rs.3,685.00', 75, ''),
+    ]
+
+    const { samples: reconciled } = reconcileGroupSamples(samples)
+
+    expect(reconciled[2].merchantRaw).toBe('24SEVEN')
+    expect(reconciled[2].amount).toBe(75)
+  })
+
+  it('keeps bootstrap values for a sample the winning template cannot read', () => {
+    const samples = [
+      sample('Rs.100.00 paid to AMAZON via UPI. Avl Bal Rs.900.00', 100, 'AMAZON'),
+      sample('Rs.250.00 paid to FLIPKART via UPI. Avl Bal Rs.650.00', 250, 'FLIPKART'),
+      sample('Card bill payment received towards ending 4523', 42, 'HDFC CARD'),
+    ]
+
+    const { samples: reconciled } = reconcileGroupSamples(samples)
+
+    expect(reconciled[2]).toEqual(samples[2])
+  })
+
+  it('reproduces the single sample of a singleton group unchanged', () => {
+    const samples = [sample('Rs.100.00 paid to AMAZON via UPI. Avl Bal Rs.900.00', 100, 'AMAZON')]
+
+    const { template, samples: reconciled } = reconcileGroupSamples(samples)
+
+    expect(template).toContain('<AMT>')
+    expect(template).toContain('<MERCHANT>')
+    expect(reconciled).toEqual(samples)
+  })
+
+  it('falls back to a first-sample proposal when no template reproduces any label', () => {
+    const samples = [
+      sample('UPI mandate executed successfully towards subscription', 999, ''),
+      sample('UPI mandate executed successfully towards subscription', 888, ''),
+    ]
+
+    const { template, samples: reconciled } = reconcileGroupSamples(samples)
+
+    expect(template).toBe('UPI mandate executed successfully towards subscription')
+    expect(reconciled).toEqual(samples)
+  })
+
+  it('returns an empty template for an empty group', () => {
+    expect(reconcileGroupSamples([])).toEqual({ template: '', samples: [] })
+  })
+})

--- a/src/utils/pattern/reconcile-group-samples.ts
+++ b/src/utils/pattern/reconcile-group-samples.ts
@@ -1,0 +1,56 @@
+import { buildTemplateFromLabels } from './build-template-from-labels'
+import { extractWithTemplate } from './extract-with-template'
+import { proposeSlots } from './propose-slots'
+
+interface GroupSample {
+  body: string
+  amount: number
+  merchantRaw: string
+}
+
+export interface ReconciledGroup<T> {
+  /** Draft extraction template for the group — the consensus winner when one exists. */
+  template: string
+  samples: T[]
+}
+
+/** Consensus building is quadratic in samples examined; groups can be large. */
+const MAX_LABEL_SAMPLES = 10
+
+/**
+ * Cross-check a group's per-message bootstrap guesses against each other.
+ * Each sample proposes a template from its own guesses; the template that
+ * reproduces the most samples wins, and every sample it can read is re-filled
+ * from it. A minority mis-extraction (balance picked over amount, missed
+ * merchant) is thereby outvoted by the group instead of surfacing in review.
+ * Samples the winner cannot read keep their bootstrap values.
+ */
+export function reconcileGroupSamples<T extends GroupSample>(samples: T[]): ReconciledGroup<T> {
+  if (samples.length === 0) return { template: '', samples }
+
+  const built = buildTemplateFromLabels(
+    samples.slice(0, MAX_LABEL_SAMPLES).map((s) => ({
+      body: s.body,
+      amount: s.amount,
+      merchant: s.merchantRaw || undefined,
+    }))
+  )
+
+  if (!built || built.accuracy === 0) {
+    const first = samples[0]
+    const { template } = proposeSlots(first.body, first.amount, first.merchantRaw || undefined)
+    return { template, samples }
+  }
+
+  const reconciled = samples.map((sample) => {
+    const extraction = extractWithTemplate(built.template, sample.body)
+    if (!extraction?.amount) return sample
+    return {
+      ...sample,
+      amount: extraction.amount,
+      merchantRaw: extraction.merchantRaw ?? sample.merchantRaw,
+    }
+  })
+
+  return { template: built.template, samples: reconciled }
+}


### PR DESCRIPTION
## Summary

Everything the pattern-review screen pre-fills on first sight of a new pattern comes from the rule-based bootstrap. This PR makes those pre-fills trustworthy, validated against a corpus of real bank SMS.

### Bootstrap extractor (`sms-data-extractor-service.ts`)
- Merchant capture rewritten: case-insensitive `at/to/from` cue scan with stop-tokens, verbatim body slices (so `proposeSlots` placement always finds them), bank self-reference and call-to-action rejection (`Call ... to report`), amount-proximity scoring, tilde-field splitting, and a UPI VPA fallback (`netflix.upi@icici`) that rejects e-mail domains. The two long-disabled merchant assertions in the spec are re-enabled.
- Amount fixes: ungrouped runs (`Rs.10000.00`) no longer truncate to 3 digits; suffix-currency amounts accept comma grouping (`1,234 INR`); `deposited` counts as a credit verb.

### Group-consensus reconcile at discovery (`reconcile-group-samples.ts`)
Each group's per-message guesses now vote: every sample proposes a template from its own labels, the template that reproduces the most samples wins, and every sample it can read is re-filled from it. A minority mis-extraction (balance picked over amount, missed digit-leading merchant like `24SEVEN`) is outvoted before the user ever sees it. The winning template becomes the stored draft instead of a single-sample proposal.

### Real-SMS corpus (`sms-extraction-corpus.spec.ts`)
27 format families distilled from an actual inbox export (ICICIT / HDFCBK / SBIUPI senders; 1,884 messages clustered to 93 shapes), with accounts, references, phones, person names, employers and localities cooked up. Asserts triage direction, amount, and merchant per format. It caught the truncation bug above plus five triage gaps, all fixed in `is-transaction-candidate.ts`: `Money Transfer:`, `Thanks for paying`, `Payment Successful!`, `Thank you for using ... Card`, and `deposited` salary credits now classify; statement `Total Amount Due` bodies no longer classify as debits via the trailing "Ignore if paid".

### Normalizer v2 (`normalize-sms-template.ts`)
- Whole plain digit runs: grouping templates no longer differ by amount magnitude (`Rs.500` vs `Rs.10000.00`).
- Fixed an alternation-precedence bug: the unwrapped `RX_NUM` interpolation leaked a bare `\d+` top-level alternative, tagging every number — dates included — as `<AMT><CUR>` and leaving the `<DATE>`/`<NUM>` paths dead.
- `VPA` added to PROTECTED words; new spec pins the v2 guarantees.
- Ships on a clean-state basis (closed beta, in-app data clear). The recompute machinery that makes future bumps migration-safe is deliberately **not** in this PR — it is specified in `docs/NORMALIZER_VERSIONING.md` for a separate PR.

## Test plan
- [x] `pnpm test` — 77 suites / 432 tests (46 new)
- [x] `pnpm type-check`
- [x] `pnpm lint` (one pre-existing unrelated warning)
- [ ] Device run: clear data → discovery → review pre-fills → approve → resync

🤖 Generated with [Claude Code](https://claude.com/claude-code)