### PR TITLE
Implement normalizer versioning and pattern recompute

### DIFF
--- a/docs/NORMALIZER_VERSIONING.md
+++ b/docs/NORMALIZER_VERSIONING.md
@@ -37,43 +37,79 @@ transaction-type tag) are safe, versioned migrations.
 
 ## Design
 
-### 1. Schema
+### 1. Schema — already shipped, verify only
 
-Add to the `patterns` table in `src/db/schema.ts`:
+`patterns.normalizerVersion` already exists: `integer('normalizer_version').notNull().default(1)`,
+added by `src/drizzle/0004_sticky_cammi.sql`. **Do not add it again and do not change the
+default.** The default stays `1` deliberately — once stamp-on-write (§2) is in place every
+insert supplies the value explicitly, so the default only ever applies to legacy rows, where
+`1` ("oldest known format") is exactly right.
 
-```
-normalizerVersion: integer('normalizer_version').notNull().default(2)
-```
+### 2. Stamp on write — confirmed missing, and live today
 
-Default = the `NORMALIZER_VERSION` live when the column ships. Run `pnpm db:generate` to
-produce the Drizzle migration. Follow the repo convention: no enums, plain const maps.
-
-### 2. Stamp on write
-
-Every write of `groupingPattern` also writes `normalizerVersion: NORMALIZER_VERSION`:
-
-- `upsertPatternsByGrouping()` — both the insert values and the `onConflictDoUpdate` set.
-- Any other writer of `groupingPattern` (grep before assuming there are none).
+Every write of `groupingPattern` also writes `normalizerVersion: NORMALIZER_VERSION`.
+The only writer (verified by grep — everything else matching `groupingPattern:` is an
+in-memory type) is `upsertPatternsByGrouping()` in
+`src/services/database/patterns-repository.ts`, and today it sets `normalizerVersion`
+**nowhere**: not in the insert values and not in the `onConflictDoUpdate` set. Fix both
+(the conflict set via `sql`excluded.normalizer_version``).
 
 `extractionPattern` writes (`updatePatternTemplateByName`) do **not** restamp — extraction
 templates are built from raw SMS bodies and are independent of the normalizer.
 
+**Consequence of the gap — plan for it, don't discover it:** every existing row, including
+rows freshly produced by the current v2 normalizer, is sitting at the DB default of `1`.
+So on the first startup after this ships, `min(normalizer_version) < NORMALIZER_VERSION`
+is true for the whole table and the recompute sweeps **every** row, not just genuinely
+stale ones. For current-format rows with samples this is a harmless no-op: re-normalize
+gives the same string, same hash, the no-collision path rewrites identical values and
+restamps. The one non-obvious interaction is a current-format `needs-review` row whose
+MMKV samples are gone: the no-samples rule below deletes it even though its
+`groupingPattern` was never stale. That is accepted behavior (see §3 step 2 rationale),
+but it must be a deliberate test case, not an accident.
+
 ### 3. Recompute on upgrade
 
-Hook: after Drizzle migrations complete in `src/app/_layout.tsx` (or a service it calls),
-run `recomputeStaleGroupingPatterns()` when
-`SELECT min(normalizer_version) FROM patterns` < `NORMALIZER_VERSION`. The version check
-itself makes the routine idempotent — no separate "has run" flag needed, and a crash midway
-resumes correctly because already-updated rows are stamped.
+Hook: register a `Migration` in the existing app-migration framework
+(`src/services/migrations/index.ts` → `appMigrations`, run by `runMigrations()` from
+`src/app/_layout.tsx` right after Drizzle's `useMigrations` succeeds — so the `patterns`
+table is guaranteed to exist).
+
+**The framework needs one widening first.** `Migration.shouldRun` is typed
+`() => boolean` and the runner filters synchronously
+(`migrations.filter((m) => m.shouldRun())` in `migration-runner.ts`). This migration's
+trigger is a DB query (`SELECT min(normalizer_version) FROM patterns` <
+`NORMALIZER_VERSION`), which is async. Decision: widen the type to
+`shouldRun: () => boolean | Promise<boolean>` and replace the runner's `filter` with a
+sequential for-loop that awaits each check. This keeps the run/skip decision in the one
+place that owns it: the runner's `pending` list — and therefore its empty-list early
+return — stays truthful, and the existing synchronous migration
+(`sms-encryption-migration`) satisfies the widened type unchanged. (The runner does no
+logging today; if telemetry is ever added, this is also where it would hang.) Do **not**
+take the "always return true, check inside run()" shortcut: every launch would then
+"run" this migration even when it internally no-ops, so the runner could never again
+distinguish nothing-to-do from work-done.
+
+The version check itself makes the routine idempotent — no separate "has run" flag
+needed, and a crash midway resumes correctly because already-updated rows are stamped.
+For this guard to hold, **every swept row must end the sweep stamped** — including the
+rows the routine chooses not to recompute (see step 2). A row left unstamped would
+re-trigger the sweep on every launch forever.
 
 Algorithm, inside one transaction, for each row with `normalizerVersion < NORMALIZER_VERSION`:
 
 1. **Load source bodies**: MMKV samples via `getPatternSamplesByName(row.name)` — each
    sample carries the original SMS `body`.
-2. **No samples available** (MMKV wiped, edge case):
-   - `needs-review` rows: delete — they are junk without samples and rediscoverable.
-   - approved/rejected rows: leave untouched (unstamped), log a warning with the pattern id.
-     Dice matching usually still works; the next re-approval restamps naturally.
+2. **No samples available** (MMKV wiped, or legacy rows on the first post-ship sweep):
+   - `needs-review` rows: delete (and their `patternSmsGroup` rows first — FK). Without
+     samples they are un-reviewable dead weight, and the residual SMS queue self-heals:
+     the next discovery run recreates the pattern with fresh samples from queued messages.
+   - approved/rejected rows: keep `name`/`groupingPattern` as-is, **stamp them current**,
+     and log a warning with the pattern id. Stamping without recompute is deliberate:
+     leaving them unstamped buys nothing (there is no future event that restores samples —
+     re-approval only writes `extractionPattern`, which per §2 does not restamp) and would
+     break the idempotency guard above. Their Dice matching either still works or the
+     pattern is effectively dead; the log line is the audit trail either way.
 3. **Re-normalize** each sample body with the current `normalizeSMSTemplate`; take the
    majority string (samples of one pattern should agree; if they tie, take the first).
 4. `newName = murmurHash32(newTemplate)`.
@@ -101,26 +137,55 @@ Algorithm, inside one transaction, for each row with `normalizerVersion < NORMAL
 
 ## Tests
 
-Unit-test the recompute routine directly (repositories mocked or against an in-memory
-SQLite as other repo tests do):
+**Harness decision.** The repo convention is _not_ in-memory SQLite — existing repository
+specs (`patterns-repository.spec.ts`) hand-mock `getDrizzleDb()`'s chained calls, and no
+`:memory:` usage exists anywhere. That convention does not survive contact with this
+routine: it is transactional and multi-table (select/update/delete across `patterns` +
+`patternSmsGroup`, plus MMKV moves), and mocking every chain would test the mock, not the
+merge logic. Use a real in-memory database for this one spec file:
+
+- Write `recomputeStaleGroupingPatterns(db, ...)` to **accept the Drizzle handle as a
+  parameter** (production passes `getDrizzleDb()`); the spec injects its own.
+- Back the spec with drizzle over **`@libsql/client`** (`:memory:`) as a devDependency,
+  applying the SQL files from `src/drizzle/` to create the schema.
+- **Do not use `better-sqlite3`**: its Drizzle driver requires _synchronous_ transaction
+  callbacks, and this codebase writes async ones against the expo driver
+  (`db.transaction(async (tx) => …)`, see `sms-encryption-migration.ts`) — the routine
+  would need two incompatible shapes. libsql's driver is async like expo's.
+- MMKV samples: mock `@/utils/mmkv/pattern-samples` with `jest.mock`, per existing
+  convention.
+
+Cases:
 
 1. Stale row + samples → renamed, restamped, MMKV re-keyed; a subsequent discovery run
    upserts into the same row (no duplicate).
 2. Two stale rows whose samples now normalize identically → merged; latest-`updatedAt`
-   status survives; usage summed; one MMKV key with ≤ 3 samples.
+   status survives; usage summed; one MMKV key with ≤ 3 samples; losing row's
+   `patternSmsGroup` rows repointed to the survivor and deduped.
 3. Approved-vs-rejected collision → latest decision wins, warning logged.
-4. Stale `needs-review` row without samples → deleted; approved row without samples →
-   untouched and unstamped.
-5. Routine is a no-op when all rows are current (and safe to run twice).
-6. Fixture realism: build "old" rows by hand-writing v1-style strings (e.g.
+4. Stale `needs-review` row without samples → deleted (with its `patternSmsGroup` rows);
+   approved row without samples → data untouched, **stamped current**, warning logged.
+5. **First-run sweep (the stamping-gap case from §2):** a row whose `groupingPattern` is
+   already in current format but whose `normalizerVersion` is at the default `1` —
+   with samples → no-op restamp, same name, same hash; without samples and `needs-review`
+   → deleted. This encodes the accepted consequence deliberately.
+6. Routine is a no-op when all rows are current (and safe to run twice — after one sweep,
+   `shouldRun` must return false).
+7. Fixture realism: build "old" rows by hand-writing v1-style strings (e.g.
    `<CUR><AMT>00.00` truncation artifacts) so the test does not depend on old code.
 
 ## Acceptance criteria
 
-- [ ] `patterns.normalizerVersion` column exists; all `groupingPattern` writers stamp it.
-- [ ] Startup recompute runs only when stale rows exist; idempotent; single transaction.
-- [ ] Renames preserve MMKV samples and `patternSmsGroup` links.
+- [ ] `upsertPatternsByGrouping` stamps `normalizerVersion` on insert **and** in its
+      `onConflictDoUpdate` set (the column itself already exists — do not re-add it).
+- [ ] `Migration.shouldRun` widened to `boolean | Promise<boolean>`; runner awaits checks
+      sequentially; existing sync migration unchanged.
+- [ ] Startup recompute runs only when stale rows exist; idempotent (every swept row ends
+      stamped, including sample-less approved/rejected rows); single transaction.
+- [ ] Renames preserve MMKV samples and `patternSmsGroup` links; merges repoint and dedupe
+      the losing row's links; deletes remove them.
 - [ ] Collisions merge with latest-decision-wins status policy, logged.
+- [ ] First-run sweep behavior (whole table at default `1`) covered by an explicit test.
 - [ ] All tests above pass; `pnpm test`, `pnpm type-check`, `pnpm lint` clean.
 - [ ] A future `NORMALIZER_VERSION` bump requires **no data clearing** — verify by bumping
       the constant in a test and asserting stored patterns keep matching after recompute.

--- a/docs/NORMALIZER_VERSIONING.md
+++ b/docs/NORMALIZER_VERSIONING.md
@@ -121,8 +121,9 @@ Algorithm, inside one transaction, for each row with `normalizerVersion < NORMAL
    - Status: if statuses differ, keep the row with the **latest `updatedAt`** (most recent
      user decision wins — matters when approved and rejected collide); log the conflict.
    - `usageCount`: sum. `createdAt`: earliest.
-   - MMKV samples: union, capped at 3 (`SAMPLES_PER_PATTERN` in
-     `pattern-discovery-service.ts`), keyed under `newName`; delete both old keys.
+   - MMKV samples: deduped by `smsId`, unioned, capped at 3 (`SAMPLES_PER_PATTERN` in
+     `src/types/constants.ts` — shared with `pattern-discovery-service.ts`, not
+     redeclared), keyed under `newName`; delete both old keys.
    - `patternSmsGroup` rows (check the FK — it references pattern **id**, so renames are
      free; merges must repoint the losing pattern's rows to the surviving id, then dedupe).
    - Delete the losing row.
@@ -146,8 +147,19 @@ merge logic. Use a real in-memory database for this one spec file:
 
 - Write `recomputeStaleGroupingPatterns(db, ...)` to **accept the Drizzle handle as a
   parameter** (production passes `getDrizzleDb()`); the spec injects its own.
-- Back the spec with drizzle over **`@libsql/client`** (`:memory:`) as a devDependency,
-  applying the SQL files from `src/drizzle/` to create the schema.
+- Back the spec with drizzle over **`@libsql/client`** as a devDependency, applying the
+  SQL files from `src/drizzle/` to create the schema.
+- **Do not use a bare `:memory:` URL.** Verified directly against `@libsql/client`,
+  outside Jest and outside Drizzle: its local driver opens a separate connection for
+  `db.transaction()`, and an anonymous `:memory:` database is private per-connection —
+  every table lookup after the first transaction fails with "no such table," even though
+  the same table worked moments earlier on the same `db` handle. **Use a real per-test
+  temp file instead** (`createClient({ url: `file:${path}` })`, deleted in `afterEach`,
+  including `-journal`/`-wal`/`-shm` siblings) — a real file is shared across connections
+  the way production SQLite is, so it doesn't hit this. (A shared-cache memory URI
+  — `file::memory:?cache=shared` — survives the transaction too, but leaks rows across
+  separate `createClient()` calls even after `.close()`, so it can't give per-test
+  isolation either; the temp file is the only option verified to give both.)
 - **Do not use `better-sqlite3`**: its Drizzle driver requires _synchronous_ transaction
   callbacks, and this codebase writes async ones against the expo driver
   (`db.transaction(async (tx) => …)`, see `sms-encryption-migration.ts`) — the routine
@@ -169,9 +181,20 @@ Cases:
    already in current format but whose `normalizerVersion` is at the default `1` —
    with samples → no-op restamp, same name, same hash; without samples and `needs-review`
    → deleted. This encodes the accepted consequence deliberately.
-6. Routine is a no-op when all rows are current (and safe to run twice — after one sweep,
+6. Samples present but unusable (every body normalizes to `''` — corrupt/empty MMKV
+   entries) → treated exactly like no-samples (delete `needs-review` / stamp-only
+   approved-rejected). Must not crash the sweep by reading `.groupingPattern` off an
+   empty group set — one bad MMKV record must not abort the whole migration.
+7. **3+-way collision within one sweep, survivor reprocessed later:** when a row that's
+   already the running survivor of an earlier merge is itself stale (e.g. the first-run
+   sweep case — already current-format, so its own recompute is a no-op rename onto its
+   own name), reprocessing it must not reset its accumulated status/usageCount/createdAt
+   back to its pre-sweep snapshot. A later collision into the same name would otherwise
+   silently undercount usage and tie-break against a stale `updatedAt` instead of the
+   folded-in one.
+8. Routine is a no-op when all rows are current (and safe to run twice — after one sweep,
    `shouldRun` must return false).
-7. Fixture realism: build "old" rows by hand-writing v1-style strings (e.g.
+9. Fixture realism: build "old" rows by hand-writing v1-style strings (e.g.
    `<CUR><AMT>00.00` truncation artifacts) so the test does not depend on old code.
 
 ## Acceptance criteria

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.28.6",
+    "@libsql/client": "^0.17.4",
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^29.5.14",
     "@types/react": "~19.1.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,7 @@ importers:
         version: 9.0.0
       drizzle-orm:
         specifier: ^0.44.5
-        version: 0.44.5(expo-sqlite@16.0.10(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))
+        version: 0.44.5(@libsql/client@0.17.4)(expo-sqlite@16.0.10(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))
       expo:
         specifier: ~54.0.36
         version: 54.0.36(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
@@ -159,6 +159,9 @@ importers:
       '@babel/core':
         specifier: ^7.28.6
         version: 7.29.7
+      '@libsql/client':
+        specifier: ^0.17.4
+        version: 0.17.4
       '@testing-library/react-native':
         specifier: ^13.3.3
         version: 13.3.3(jest@29.7.0(@types/node@24.3.1))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1553,11 +1556,71 @@ packages:
   '@jridgewell/trace-mapping@0.3.30':
     resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
 
+  '@libsql/client@0.17.4':
+    resolution: {integrity: sha512-lYayFWasDV78A+TjlEhr6ubb3odBV6OHjb+wdp8VQcyWWAEIjuwbCHaraEUS4m4yWoo0BvZo96It4VdzZRmRWw==}
+
+  '@libsql/core@0.17.4':
+    resolution: {integrity: sha512-LqF9gIvnJ38nmAH1y/ChizHqDO/MO1wLgA96XrraulEEbqXxLjleSH92YWTolbuJKgPUmGu4aJk9W3UnAcxLOQ==}
+
+  '@libsql/darwin-arm64@0.5.29':
+    resolution: {integrity: sha512-K+2RIB1OGFPYQbfay48GakLhqf3ArcbHqPFu7EZiaUcRgFcdw8RoltsMyvbj5ix2fY0HV3Q3Ioa/ByvQdaSM0A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@libsql/darwin-x64@0.5.29':
+    resolution: {integrity: sha512-OtT+KFHsKFy1R5FVadr8FJ2Bb1mghtXTyJkxv0trocq7NuHntSki1eUbxpO5ezJesDvBlqFjnWaYYY516QNLhQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@libsql/hrana-client@0.10.0':
+    resolution: {integrity: sha512-OoA4EMqRAC7kn7V2P6EQqRcpZf2W+AjsNIyCizBg339Tq/aMC7sRnzs3SklderhmQWAqEzvv8A2vhxVmWpkVvw==}
+
+  '@libsql/isomorphic-ws@0.1.5':
+    resolution: {integrity: sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg==}
+
+  '@libsql/linux-arm-gnueabihf@0.5.29':
+    resolution: {integrity: sha512-CD4n4zj7SJTHso4nf5cuMoWoMSS7asn5hHygsDuhRl8jjjCTT3yE+xdUvI4J7zsyb53VO5ISh4cwwOtf6k2UhQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@libsql/linux-arm-musleabihf@0.5.29':
+    resolution: {integrity: sha512-2Z9qBVpEJV7OeflzIR3+l5yAd4uTOLxklScYTwpZnkm2vDSGlC1PRlueLaufc4EFITkLKXK2MWBpexuNJfMVcg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@libsql/linux-arm64-gnu@0.5.29':
+    resolution: {integrity: sha512-gURBqaiXIGGwFNEaUj8Ldk7Hps4STtG+31aEidCk5evMMdtsdfL3HPCpvys+ZF/tkOs2MWlRWoSq7SOuCE9k3w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@libsql/linux-arm64-musl@0.5.29':
+    resolution: {integrity: sha512-fwgYZ0H8mUkyVqXZHF3mT/92iIh1N94Owi/f66cPVNsk9BdGKq5gVpoKO+7UxaNzuEH1roJp2QEwsCZMvBLpqg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@libsql/linux-x64-gnu@0.5.29':
+    resolution: {integrity: sha512-y14V0vY0nmMC6G0pHeJcEarcnGU2H6cm21ZceRkacWHvQAEhAG0latQkCtoS2njFOXiYIg+JYPfAoWKbi82rkg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@libsql/linux-x64-musl@0.5.29':
+    resolution: {integrity: sha512-gquqwA/39tH4pFl+J9n3SOMSymjX+6kZ3kWgY3b94nXFTwac9bnFNMffIomgvlFaC4ArVqMnOZD3nuJ3H3VO1w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@libsql/win32-x64-msvc@0.5.29':
+    resolution: {integrity: sha512-4/0CvEdhi6+KjMxMaVbFM2n2Z44escBRoEYpR+gZg64DdetzGnYm8mcNLcoySaDJZNaBd6wz5DNdgRmcI4hXcg==}
+    cpu: [x64]
+    os: [win32]
+
   '@lucide/lab@0.1.2':
     resolution: {integrity: sha512-VprF2BJa7ZuTGOhUd5cf8tHJXyL63wdxcGieAiVVoR9hO0YmPsnZO0AGqDiX2/br+/MC6n8BoJcmPilltOXIJA==}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
+  '@neon-rs/load@0.0.4':
+    resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2052,6 +2115,9 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -2961,6 +3027,10 @@ packages:
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  detect-libc@2.0.2:
+    resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
+    engines: {node: '>=8'}
 
   detect-libc@2.1.1:
     resolution: {integrity: sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==}
@@ -4442,6 +4512,9 @@ packages:
   jimp-compact@0.16.1:
     resolution: {integrity: sha512-dZ6Ra7u1G8c4Letq/B5EzAxj4tLFHL+cGtdpR+PVm4yzPDj+lCk+AbivWt1eOM+ikzkowtyV7qSqX6qr3t71Ww==}
 
+  js-base64@3.9.2:
+    resolution: {integrity: sha512-6zayE8QlUdiweYI6cETD/XBSqFcoCUlufn/29PJR99r82x1yDnIprRca0YvAYpAW+ez0GuQkVBC6xG5QkD7OjA==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -4533,6 +4606,11 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  libsql@0.5.29:
+    resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
+    cpu: [x64, arm64, wasm32, arm]
+    os: [darwin, linux, win32]
 
   lighthouse-logger@1.4.2:
     resolution: {integrity: sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==}
@@ -5333,6 +5411,9 @@ packages:
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
+
+  promise-limit@2.7.0:
+    resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
 
   promise@7.3.1:
     resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
@@ -8234,6 +8315,64 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@libsql/client@0.17.4':
+    dependencies:
+      '@libsql/core': 0.17.4
+      '@libsql/hrana-client': 0.10.0
+      js-base64: 3.9.2
+      libsql: 0.5.29
+      promise-limit: 2.7.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@libsql/core@0.17.4':
+    dependencies:
+      js-base64: 3.9.2
+
+  '@libsql/darwin-arm64@0.5.29':
+    optional: true
+
+  '@libsql/darwin-x64@0.5.29':
+    optional: true
+
+  '@libsql/hrana-client@0.10.0':
+    dependencies:
+      '@libsql/isomorphic-ws': 0.1.5
+      js-base64: 3.9.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@libsql/isomorphic-ws@0.1.5':
+    dependencies:
+      '@types/ws': 8.18.1
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@libsql/linux-arm-gnueabihf@0.5.29':
+    optional: true
+
+  '@libsql/linux-arm-musleabihf@0.5.29':
+    optional: true
+
+  '@libsql/linux-arm64-gnu@0.5.29':
+    optional: true
+
+  '@libsql/linux-arm64-musl@0.5.29':
+    optional: true
+
+  '@libsql/linux-x64-gnu@0.5.29':
+    optional: true
+
+  '@libsql/linux-x64-musl@0.5.29':
+    optional: true
+
+  '@libsql/win32-x64-msvc@0.5.29':
+    optional: true
+
   '@lucide/lab@0.1.2': {}
 
   '@napi-rs/wasm-runtime@0.2.12':
@@ -8242,6 +8381,8 @@ snapshots:
       '@emnapi/runtime': 1.5.0
       '@tybys/wasm-util': 0.10.0
     optional: true
+
+  '@neon-rs/load@0.0.4': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -8773,6 +8914,10 @@ snapshots:
   '@types/stack-utils@2.0.3': {}
 
   '@types/tough-cookie@4.0.5': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 24.3.1
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -9744,6 +9889,8 @@ snapshots:
 
   destroy@1.2.0: {}
 
+  detect-libc@2.0.2: {}
+
   detect-libc@2.1.1: {}
 
   detect-newline@3.1.0: {}
@@ -9799,8 +9946,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.44.5(expo-sqlite@16.0.10(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)):
+  drizzle-orm@0.44.5(@libsql/client@0.17.4)(expo-sqlite@16.0.10(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)):
     optionalDependencies:
+      '@libsql/client': 0.17.4
       expo-sqlite: 16.0.10(expo@54.0.36)(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
 
   dunder-proto@1.0.1:
@@ -11576,6 +11724,8 @@ snapshots:
 
   jimp-compact@0.16.1: {}
 
+  js-base64@3.9.2: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.1:
@@ -11673,6 +11823,21 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  libsql@0.5.29:
+    dependencies:
+      '@neon-rs/load': 0.0.4
+      detect-libc: 2.0.2
+    optionalDependencies:
+      '@libsql/darwin-arm64': 0.5.29
+      '@libsql/darwin-x64': 0.5.29
+      '@libsql/linux-arm-gnueabihf': 0.5.29
+      '@libsql/linux-arm-musleabihf': 0.5.29
+      '@libsql/linux-arm64-gnu': 0.5.29
+      '@libsql/linux-arm64-musl': 0.5.29
+      '@libsql/linux-x64-gnu': 0.5.29
+      '@libsql/linux-x64-musl': 0.5.29
+      '@libsql/win32-x64-msvc': 0.5.29
 
   lighthouse-logger@1.4.2:
     dependencies:
@@ -12678,6 +12843,8 @@ snapshots:
   process@0.11.10: {}
 
   progress@2.0.3: {}
+
+  promise-limit@2.7.0: {}
 
   promise@7.3.1:
     dependencies:

--- a/src/components/category-selector/category-selector.spec.tsx
+++ b/src/components/category-selector/category-selector.spec.tsx
@@ -52,7 +52,7 @@ describe('CategorySelector', () => {
   })
 
   it('does not allow selecting more than MAX_CATEGORIES', () => {
-    const selectedCategories = ['Food', 'Transportation', 'Groceries', 'Utilities']
+    const selectedCategories = availableCategories.slice(0, MAX_CATEGORIES)
     const { getByText } = render(
       <CategorySelector
         selectedCategories={selectedCategories}
@@ -103,7 +103,7 @@ describe('CategorySelector', () => {
   })
 
   it('does not auto-select custom category when at MAX_CATEGORIES', () => {
-    const selectedCategories = ['Food', 'Transportation', 'Groceries', 'Utilities']
+    const selectedCategories = availableCategories.slice(0, MAX_CATEGORIES)
     const { getByText, getByPlaceholderText } = render(
       <CategorySelector
         selectedCategories={selectedCategories}

--- a/src/services/database/patterns-repository.spec.ts
+++ b/src/services/database/patterns-repository.spec.ts
@@ -1,12 +1,19 @@
 import type { Pattern } from '@/db/schema'
-import { getPatterns } from './patterns-repository'
+import type { DistinctPattern } from '@/types/sms/transaction'
+import { NORMALIZER_VERSION } from '@/utils/pattern/normalize-sms-template'
+import { getPatterns, upsertPatternsByGrouping } from './patterns-repository'
 
 const mockFrom = jest.fn()
+const mockValues = jest.fn()
+const mockOnConflictDoUpdate = jest.fn()
 
 jest.mock('./db', () => ({
   getDrizzleDb: jest.fn(() => ({
     select: () => ({
       from: mockFrom,
+    }),
+    insert: () => ({
+      values: mockValues,
     }),
   })),
 }))
@@ -93,5 +100,40 @@ describe('getPatterns', () => {
     const result = await getPatterns()
 
     expect(result).toEqual({ active: [], rejected: [] })
+  })
+})
+
+describe('upsertPatternsByGrouping', () => {
+  function makeDistinctPattern(overrides: Partial<DistinctPattern> = {}): DistinctPattern {
+    return {
+      id: '1',
+      template: 'extraction template',
+      groupingTemplate: 'grouping template',
+      occurrences: 1,
+      transactions: [],
+      patternType: 'debit',
+      status: 'needs-review',
+      ...overrides,
+    }
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockValues.mockReturnValue({ onConflictDoUpdate: mockOnConflictDoUpdate })
+    mockOnConflictDoUpdate.mockReturnValue(Promise.resolve())
+  })
+
+  it('stamps the current NORMALIZER_VERSION on insert', async () => {
+    await upsertPatternsByGrouping([makeDistinctPattern()])
+
+    const insertedRows = mockValues.mock.calls[0][0]
+    expect(insertedRows[0].normalizerVersion).toBe(NORMALIZER_VERSION)
+  })
+
+  it('stamps the current NORMALIZER_VERSION in the conflict-update set', async () => {
+    await upsertPatternsByGrouping([makeDistinctPattern()])
+
+    const conflictConfig = mockOnConflictDoUpdate.mock.calls[0][0]
+    expect(conflictConfig.set.normalizerVersion).toBeDefined()
   })
 })

--- a/src/services/database/patterns-repository.ts
+++ b/src/services/database/patterns-repository.ts
@@ -9,6 +9,7 @@ import {
 import { FilterOptions } from '@/types/filters'
 import type { DistinctPattern } from '@/types/sms/transaction'
 import { murmurHash32 } from '@/utils/hash/murmur32'
+import { NORMALIZER_VERSION } from '@/utils/pattern/normalize-sms-template'
 import { and, eq, gte, sql } from 'drizzle-orm'
 import { getDrizzleDb } from './db'
 
@@ -18,6 +19,7 @@ export async function upsertPatternsByGrouping(distinct: DistinctPattern[]): Pro
     name: murmurHash32(p.groupingTemplate),
     groupingPattern: p.groupingTemplate,
     extractionPattern: p.template,
+    normalizerVersion: NORMALIZER_VERSION,
     type: TRANSACTION_TYPE.Debit,
     status: p.status,
     isActive: true,
@@ -33,6 +35,7 @@ export async function upsertPatternsByGrouping(distinct: DistinctPattern[]): Pro
       target: patterns.name,
       set: {
         extractionPattern: sql`excluded.extraction_pattern`,
+        normalizerVersion: sql`excluded.normalizer_version`,
         type: sql`excluded.type`,
         status: sql`excluded.status`,
         updatedAt: new Date(),

--- a/src/services/migrations/index.ts
+++ b/src/services/migrations/index.ts
@@ -1,7 +1,8 @@
 import { Migration } from './migration-runner'
+import { normalizerRecomputeMigration } from './normalizer-recompute-migration'
 import { smsEncryptionMigration } from './sms-encryption-migration'
 
-export const appMigrations: Migration[] = [smsEncryptionMigration]
+export const appMigrations: Migration[] = [smsEncryptionMigration, normalizerRecomputeMigration]
 
 export { runMigrations } from './migration-runner'
 export type { Migration, MigrationRunnerResult } from './migration-runner'

--- a/src/services/migrations/migration-runner.spec.ts
+++ b/src/services/migrations/migration-runner.spec.ts
@@ -1,0 +1,112 @@
+import { runMigrations, type Migration } from './migration-runner'
+
+function makeMigration(overrides: Partial<Migration>): Migration {
+  return {
+    id: 'test-migration',
+    name: 'Test Migration',
+    shouldRun: () => true,
+    run: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+}
+
+describe('runMigrations', () => {
+  it('runs a migration whose shouldRun is synchronously true', async () => {
+    const run = jest.fn().mockResolvedValue(undefined)
+    const migration = makeMigration({ shouldRun: () => true, run })
+
+    const result = await runMigrations([migration])
+
+    expect(result).toEqual({ success: true })
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips a migration whose shouldRun is synchronously false', async () => {
+    const run = jest.fn().mockResolvedValue(undefined)
+    const migration = makeMigration({ shouldRun: () => false, run })
+
+    const result = await runMigrations([migration])
+
+    expect(result).toEqual({ success: true })
+    expect(run).not.toHaveBeenCalled()
+  })
+
+  it('runs a migration whose shouldRun resolves true asynchronously', async () => {
+    const run = jest.fn().mockResolvedValue(undefined)
+    const migration = makeMigration({ shouldRun: () => Promise.resolve(true), run })
+
+    const result = await runMigrations([migration])
+
+    expect(result).toEqual({ success: true })
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips a migration whose shouldRun resolves false asynchronously', async () => {
+    const run = jest.fn().mockResolvedValue(undefined)
+    const migration = makeMigration({ shouldRun: () => Promise.resolve(false), run })
+
+    const result = await runMigrations([migration])
+
+    expect(result).toEqual({ success: true })
+    expect(run).not.toHaveBeenCalled()
+  })
+
+  it('does not call run for any migration when every shouldRun is false', async () => {
+    const runA = jest.fn().mockResolvedValue(undefined)
+    const runB = jest.fn().mockResolvedValue(undefined)
+
+    const result = await runMigrations([
+      makeMigration({ id: 'a', shouldRun: () => false, run: runA }),
+      makeMigration({ id: 'b', shouldRun: () => Promise.resolve(false), run: runB }),
+    ])
+
+    expect(result).toEqual({ success: true })
+    expect(runA).not.toHaveBeenCalled()
+    expect(runB).not.toHaveBeenCalled()
+  })
+
+  it('runs only the migrations whose shouldRun is true, preserving order', async () => {
+    const calls: string[] = []
+    const migrations = [
+      makeMigration({
+        id: 'skip-me',
+        shouldRun: () => false,
+        run: jest.fn(async () => {
+          calls.push('skip-me')
+        }),
+      }),
+      makeMigration({
+        id: 'run-me-1',
+        shouldRun: () => true,
+        run: jest.fn(async () => {
+          calls.push('run-me-1')
+        }),
+      }),
+      makeMigration({
+        id: 'run-me-2',
+        shouldRun: () => Promise.resolve(true),
+        run: jest.fn(async () => {
+          calls.push('run-me-2')
+        }),
+      }),
+    ]
+
+    const result = await runMigrations(migrations)
+
+    expect(result).toEqual({ success: true })
+    expect(calls).toEqual(['run-me-1', 'run-me-2'])
+  })
+
+  it('returns a namespaced error and stops when a migration throws', async () => {
+    const runA = jest.fn().mockRejectedValue(new Error('boom'))
+    const runB = jest.fn().mockResolvedValue(undefined)
+
+    const result = await runMigrations([
+      makeMigration({ id: 'a', shouldRun: () => true, run: runA }),
+      makeMigration({ id: 'b', shouldRun: () => true, run: runB }),
+    ])
+
+    expect(result).toEqual({ success: false, error: 'a: boom' })
+    expect(runB).not.toHaveBeenCalled()
+  })
+})

--- a/src/services/migrations/migration-runner.ts
+++ b/src/services/migrations/migration-runner.ts
@@ -1,7 +1,7 @@
 export interface Migration {
   id: string
   name: string
-  shouldRun: () => boolean
+  shouldRun: () => boolean | Promise<boolean>
   run: () => Promise<void>
 }
 
@@ -11,7 +11,12 @@ export interface MigrationRunnerResult {
 }
 
 export async function runMigrations(migrations: Migration[]): Promise<MigrationRunnerResult> {
-  const pending = migrations.filter((m) => m.shouldRun())
+  const pending: Migration[] = []
+  for (const migration of migrations) {
+    if (await migration.shouldRun()) {
+      pending.push(migration)
+    }
+  }
 
   if (pending.length === 0) {
     return { success: true }

--- a/src/services/migrations/normalizer-recompute-migration.spec.ts
+++ b/src/services/migrations/normalizer-recompute-migration.spec.ts
@@ -1,0 +1,352 @@
+import * as schema from '@/db/schema'
+import {
+  PATTERN_STATUS,
+  patterns,
+  patternSmsGroup,
+  smsMessages,
+  TRANSACTION_TYPE,
+  type NewPattern,
+  type NewSmsMessage,
+} from '@/db/schema'
+import type { ReviewTxn } from '@/types/sms-parsing'
+import { murmurHash32 } from '@/utils/hash/murmur32'
+import {
+  deletePatternSamplesByName,
+  getPatternSamplesByName,
+  setPatternSamplesByName,
+} from '@/utils/mmkv/pattern-samples'
+import { NORMALIZER_VERSION, normalizeSMSTemplate } from '@/utils/pattern/normalize-sms-template'
+import { createClient } from '@libsql/client/node'
+import { eq } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/libsql'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { recomputeStaleGroupingPatterns } from './normalizer-recompute-migration'
+
+jest.mock('@/utils/mmkv/pattern-samples', () => ({
+  getPatternSamplesByName: jest.fn(),
+  setPatternSamplesByName: jest.fn(),
+  deletePatternSamplesByName: jest.fn(),
+}))
+
+const mockGetSamples = getPatternSamplesByName as jest.Mock
+const mockSetSamples = setPatternSamplesByName as jest.Mock
+const mockDeleteSamples = deletePatternSamplesByName as jest.Mock
+
+// Real SMS bodies, re-normalized by the CURRENT normalizer — never hand-computed, so
+// the test can't drift from what normalizeSMSTemplate actually produces.
+const CURRENT_BODIES = [
+  'Rs.100 debited from a/c XX1234 for amazon',
+  'Rs.250 debited from a/c XX5678 for amazon',
+  'Rs.999 debited from a/c XX9999 for amazon',
+]
+const CURRENT_TEMPLATE = normalizeSMSTemplate(CURRENT_BODIES[0])
+const CURRENT_NAME = murmurHash32(CURRENT_TEMPLATE)
+
+function makeSample(overrides: Partial<ReviewTxn> = {}): ReviewTxn {
+  return {
+    smsId: 1,
+    amount: 100,
+    type: TRANSACTION_TYPE.Debit,
+    merchantRaw: 'amazon',
+    date: Date.now(),
+    sender: 'VM-TESTBK',
+    body: CURRENT_BODIES[0],
+    ...overrides,
+  }
+}
+
+// A bare `:memory:` URL is not usable here: @libsql/client's local driver opens a
+// separate connection for db.transaction(), and an anonymous `:memory:` database is
+// private per-connection, so the schema "disappears" (verified directly against
+// @libsql/client, outside Jest/Drizzle — every table lookup after a transaction fails
+// with "no such table"). A real temp file is shared across connections like production
+// SQLite is, so it doesn't hit this.
+function tempDbPath(): string {
+  return path.join(os.tmpdir(), `rose-wallet-test-${process.pid}-${Math.random().toString(36).slice(2)}.db`)
+}
+
+function removeDbFile(file: string) {
+  for (const suffix of ['', '-journal', '-wal', '-shm']) {
+    fs.rmSync(`${file}${suffix}`, { force: true })
+  }
+}
+
+async function createTestDb(file: string) {
+  const client = createClient({ url: `file:${file}` })
+  const drizzleDir = path.join(__dirname, '../../drizzle')
+  const files = fs
+    .readdirSync(drizzleDir)
+    .filter((f) => f.endsWith('.sql'))
+    .sort()
+  for (const migrationFile of files) {
+    await client.executeMultiple(fs.readFileSync(path.join(drizzleDir, migrationFile), 'utf-8'))
+  }
+  return { client, db: drizzle(client, { schema }) }
+}
+
+describe('recomputeStaleGroupingPatterns', () => {
+  let client: Awaited<ReturnType<typeof createTestDb>>['client']
+  let db: Awaited<ReturnType<typeof createTestDb>>['db']
+  let dbFile: string
+  let sampleStore: Record<string, ReviewTxn[]>
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    sampleStore = {}
+    mockGetSamples.mockImplementation((name: string) => sampleStore[name] ?? [])
+    mockSetSamples.mockImplementation((name: string, samples: ReviewTxn[]) => {
+      sampleStore[name] = samples
+    })
+    mockDeleteSamples.mockImplementation((name: string) => {
+      delete sampleStore[name]
+    })
+
+    dbFile = tempDbPath()
+    const created = await createTestDb(dbFile)
+    client = created.client
+    db = created.db
+  })
+
+  afterEach(() => {
+    client.close()
+    removeDbFile(dbFile)
+  })
+
+  async function insertPattern(overrides: Partial<NewPattern> = {}) {
+    const base: NewPattern = {
+      name: 'legacy-name',
+      groupingPattern: '<CUR><AMT>00.00 legacy template',
+      extractionPattern: 'template',
+      normalizerVersion: 1,
+      type: TRANSACTION_TYPE.Debit,
+      status: PATTERN_STATUS.NeedsReview,
+      isActive: true,
+      usageCount: 0,
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      updatedAt: new Date('2026-01-01T00:00:00Z'),
+      ...overrides,
+    }
+    const [row] = await db.insert(patterns).values(base).returning()
+    return row
+  }
+
+  async function insertSms(overrides: Partial<NewSmsMessage> = {}) {
+    const base: NewSmsMessage = {
+      sender: 'VM-TESTBK',
+      body: 'test sms body',
+      dateTime: new Date('2026-01-01T00:00:00Z'),
+      ...overrides,
+    }
+    const [row] = await db.insert(smsMessages).values(base).returning()
+    return row
+  }
+
+  async function insertLink(patternId: number, smsId: number) {
+    const [row] = await db.insert(patternSmsGroup).values({ patternId, smsId, confidence: 1 }).returning()
+    return row
+  }
+
+  async function allRows() {
+    return db.select().from(patterns)
+  }
+
+  async function linksFor(patternId: number) {
+    return db.select().from(patternSmsGroup).where(eq(patternSmsGroup.patternId, patternId))
+  }
+
+  it('renames a stale row with samples, restamps it, and re-keys MMKV', async () => {
+    const row = await insertPattern({
+      name: 'legacy-name-rename',
+      groupingPattern: '<CUR><AMT>00.00 legacy from a/c <NUM> amazon',
+      status: PATTERN_STATUS.Approved,
+    })
+    sampleStore['legacy-name-rename'] = CURRENT_BODIES.map((body) => makeSample({ body }))
+
+    const summary = await recomputeStaleGroupingPatterns(db)
+
+    expect(summary).toEqual({ renamed: 1, merged: 0, deleted: 0, stampedOnly: 0 })
+
+    const [updated] = await db.select().from(patterns).where(eq(patterns.id, row.id))
+    expect(updated.name).toBe(CURRENT_NAME)
+    expect(updated.groupingPattern).toBe(CURRENT_TEMPLATE)
+    expect(updated.normalizerVersion).toBe(NORMALIZER_VERSION)
+
+    expect(sampleStore['legacy-name-rename']).toBeUndefined()
+    expect(sampleStore[CURRENT_NAME]).toHaveLength(3)
+  })
+
+  it('merges two stale rows whose samples now normalize identically', async () => {
+    const rowA = await insertPattern({
+      name: 'legacy-a',
+      groupingPattern: '<CUR><AMT>00.00 legacy a',
+      status: PATTERN_STATUS.Approved,
+      usageCount: 5,
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      updatedAt: new Date('2026-01-10T00:00:00Z'),
+    })
+    const rowB = await insertPattern({
+      name: 'legacy-b',
+      groupingPattern: '<CUR> <AMT> legacy b variant',
+      status: PATTERN_STATUS.Rejected,
+      usageCount: 2,
+      createdAt: new Date('2026-01-05T00:00:00Z'),
+      updatedAt: new Date('2026-01-20T00:00:00Z'), // later than A — B's status should win
+    })
+    const sms201 = await insertSms()
+    const sms202 = await insertSms()
+    const sms203 = await insertSms() // shared by both patterns' links below — must dedupe after repoint
+
+    sampleStore['legacy-a'] = [
+      makeSample({ body: CURRENT_BODIES[0], smsId: sms201.id }),
+      makeSample({ body: CURRENT_BODIES[1], smsId: sms203.id }),
+    ]
+    sampleStore['legacy-b'] = [
+      makeSample({ body: CURRENT_BODIES[2], smsId: sms202.id }),
+      makeSample({ body: CURRENT_BODIES[0], smsId: sms203.id }),
+    ]
+
+    await insertLink(rowA.id, sms201.id)
+    await insertLink(rowA.id, sms203.id)
+    await insertLink(rowB.id, sms202.id)
+    await insertLink(rowB.id, sms203.id)
+
+    const summary = await recomputeStaleGroupingPatterns(db)
+
+    // rowA is processed first and claims the converged name via a rename (neither row
+    // started out named that); rowB then collides into it and merges.
+    expect(summary).toEqual({ renamed: 1, merged: 1, deleted: 0, stampedOnly: 0 })
+
+    const rows = await allRows()
+    expect(rows).toHaveLength(1)
+    const survivor = rows[0]
+    expect(survivor.name).toBe(CURRENT_NAME)
+    expect(survivor.status).toBe(PATTERN_STATUS.Rejected) // B's status — B.updatedAt is later
+    expect(survivor.usageCount).toBe(7) // 5 + 2
+    expect(survivor.createdAt.getTime()).toBe(new Date('2026-01-01T00:00:00Z').getTime()) // earliest of the two
+    expect(survivor.normalizerVersion).toBe(NORMALIZER_VERSION)
+
+    expect(sampleStore['legacy-a']).toBeUndefined()
+    expect(sampleStore['legacy-b']).toBeUndefined()
+    expect(sampleStore[CURRENT_NAME]).toHaveLength(3) // 4 unioned, capped at SAMPLES_PER_PATTERN
+
+    const links = await linksFor(survivor.id)
+    const smsIds = links.map((l) => l.smsId).sort((a, b) => a - b)
+    expect(smsIds).toEqual([sms201.id, sms202.id, sms203.id].sort((a, b) => a - b)) // 203 deduped, not doubled
+  })
+
+  it('resolves an approved-vs-rejected collision by latest updatedAt and logs a warning', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await insertPattern({
+      name: 'legacy-approved',
+      groupingPattern: '<CUR><AMT>00.00 legacy approved',
+      status: PATTERN_STATUS.Approved,
+      updatedAt: new Date('2026-02-01T00:00:00Z'), // newer than the rejected row below
+    })
+    await insertPattern({
+      name: 'legacy-rejected',
+      groupingPattern: '<CUR> <AMT> legacy rejected',
+      status: PATTERN_STATUS.Rejected,
+      updatedAt: new Date('2026-01-01T00:00:00Z'),
+    })
+    sampleStore['legacy-approved'] = [makeSample({ body: CURRENT_BODIES[0] })]
+    sampleStore['legacy-rejected'] = [makeSample({ body: CURRENT_BODIES[1] })]
+
+    await recomputeStaleGroupingPatterns(db)
+
+    const rows = await allRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].status).toBe(PATTERN_STATUS.Approved) // approved row is the newer decision
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('merged pattern'))
+
+    warnSpy.mockRestore()
+  })
+
+  it('deletes a stale needs-review row without samples, and its patternSmsGroup links', async () => {
+    const row = await insertPattern({ name: 'orphan-needs-review', status: PATTERN_STATUS.NeedsReview })
+    const sms = await insertSms()
+    await insertLink(row.id, sms.id)
+    // no MMKV samples seeded — getPatternSamplesByName returns []
+
+    const summary = await recomputeStaleGroupingPatterns(db)
+
+    expect(summary).toEqual({ renamed: 0, merged: 0, deleted: 1, stampedOnly: 0 })
+    const remaining = await db.select().from(patterns).where(eq(patterns.id, row.id))
+    expect(remaining).toHaveLength(0)
+    expect(await linksFor(row.id)).toHaveLength(0)
+  })
+
+  it('stamps an approved row without samples, leaving it untouched, and logs a warning', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const row = await insertPattern({
+      name: 'orphan-approved',
+      groupingPattern: '<CUR><AMT>00.00 orphan approved',
+      status: PATTERN_STATUS.Approved,
+    })
+
+    const summary = await recomputeStaleGroupingPatterns(db)
+
+    expect(summary).toEqual({ renamed: 0, merged: 0, deleted: 0, stampedOnly: 1 })
+    const [updated] = await db.select().from(patterns).where(eq(patterns.id, row.id))
+    expect(updated.name).toBe('orphan-approved')
+    expect(updated.groupingPattern).toBe('<CUR><AMT>00.00 orphan approved')
+    expect(updated.normalizerVersion).toBe(NORMALIZER_VERSION)
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(`pattern ${row.id}`))
+
+    warnSpy.mockRestore()
+  })
+
+  describe('first-run sweep (the stamping-gap: rows already current-format but stamped at the default 1)', () => {
+    it('no-op restamps a row whose groupingPattern is already current-format, when samples exist', async () => {
+      const row = await insertPattern({
+        name: CURRENT_NAME,
+        groupingPattern: CURRENT_TEMPLATE,
+        status: PATTERN_STATUS.Approved,
+      })
+      sampleStore[CURRENT_NAME] = CURRENT_BODIES.map((body) => makeSample({ body }))
+
+      const summary = await recomputeStaleGroupingPatterns(db)
+
+      expect(summary).toEqual({ renamed: 1, merged: 0, deleted: 0, stampedOnly: 0 })
+      const [updated] = await db.select().from(patterns).where(eq(patterns.id, row.id))
+      expect(updated.name).toBe(CURRENT_NAME)
+      expect(updated.groupingPattern).toBe(CURRENT_TEMPLATE)
+      expect(updated.normalizerVersion).toBe(NORMALIZER_VERSION)
+    })
+
+    it('deletes an already current-format needs-review row when samples are missing', async () => {
+      const row = await insertPattern({
+        name: CURRENT_NAME,
+        groupingPattern: CURRENT_TEMPLATE,
+        status: PATTERN_STATUS.NeedsReview,
+      })
+      // no samples seeded
+
+      const summary = await recomputeStaleGroupingPatterns(db)
+
+      expect(summary).toEqual({ renamed: 0, merged: 0, deleted: 1, stampedOnly: 0 })
+      expect(await db.select().from(patterns).where(eq(patterns.id, row.id))).toHaveLength(0)
+    })
+  })
+
+  it('is a no-op when all rows are already current', async () => {
+    await insertPattern({ name: 'already-current', normalizerVersion: NORMALIZER_VERSION })
+
+    const summary = await recomputeStaleGroupingPatterns(db)
+
+    expect(summary).toEqual({ renamed: 0, merged: 0, deleted: 0, stampedOnly: 0 })
+  })
+
+  it('is safe to run twice — the second run touches nothing', async () => {
+    await insertPattern({ name: 'legacy-idempotent', status: PATTERN_STATUS.Approved })
+    sampleStore['legacy-idempotent'] = CURRENT_BODIES.map((body) => makeSample({ body }))
+
+    const first = await recomputeStaleGroupingPatterns(db)
+    expect(first.renamed).toBe(1)
+
+    const second = await recomputeStaleGroupingPatterns(db)
+    expect(second).toEqual({ renamed: 0, merged: 0, deleted: 0, stampedOnly: 0 })
+  })
+})

--- a/src/services/migrations/normalizer-recompute-migration.spec.ts
+++ b/src/services/migrations/normalizer-recompute-migration.spec.ts
@@ -8,13 +8,17 @@ import {
   type NewPattern,
   type NewSmsMessage,
 } from '@/db/schema'
+import { upsertPatternsByGrouping } from '@/services/database/patterns-repository'
 import type { ReviewTxn } from '@/types/sms-parsing'
+import type { DistinctPattern } from '@/types/sms/transaction'
 import { murmurHash32 } from '@/utils/hash/murmur32'
 import {
   deletePatternSamplesByName,
   getPatternSamplesByName,
   setPatternSamplesByName,
 } from '@/utils/mmkv/pattern-samples'
+import { bigrams } from '@/utils/pattern/bigrams'
+import { matchPattern } from '@/utils/pattern/match-pattern'
 import { NORMALIZER_VERSION, normalizeSMSTemplate } from '@/utils/pattern/normalize-sms-template'
 import { createClient } from '@libsql/client/node'
 import { eq } from 'drizzle-orm'
@@ -28,6 +32,13 @@ jest.mock('@/utils/mmkv/pattern-samples', () => ({
   getPatternSamplesByName: jest.fn(),
   setPatternSamplesByName: jest.fn(),
   deletePatternSamplesByName: jest.fn(),
+}))
+
+// Lets the real upsertPatternsByGrouping run against the injected libsql test DB
+// (the continuity tests exercise the actual discovery conflict path, not a mock).
+let mockDb: ReturnType<typeof drizzle> | undefined
+jest.mock('@/services/database/db', () => ({
+  getDrizzleDb: () => mockDb,
 }))
 
 const mockGetSamples = getPatternSamplesByName as jest.Mock
@@ -107,6 +118,7 @@ describe('recomputeStaleGroupingPatterns', () => {
     const created = await createTestDb(dbFile)
     client = created.client
     db = created.db
+    mockDb = db
   })
 
   afterEach(() => {
@@ -436,5 +448,146 @@ describe('recomputeStaleGroupingPatterns', () => {
 
     const second = await recomputeStaleGroupingPatterns(db)
     expect(second).toEqual({ recomputed: 0, merged: 0, deleted: 0, stampedOnly: 0 })
+  })
+
+  describe('continuity across a normalizer bump (doc acceptance criterion)', () => {
+    // The constant itself can't be bumped inside a test, but a bump's observable state
+    // can: rows stamped below NORMALIZER_VERSION whose groupingPattern is an older
+    // format, with MMKV samples carrying the original bodies. Bodies below are real
+    // format families from sms-extraction-corpus.spec.ts (digits/names cooked per its
+    // convention); each family seeds two sample bodies, and `fresh` is a held-out
+    // message of the same format "arriving" after the recompute.
+    interface ContinuityFamily {
+      staleName: string
+      staleTemplate: string
+      status: (typeof PATTERN_STATUS)[keyof typeof PATTERN_STATUS]
+      samples: string[]
+      fresh: string
+    }
+
+    // corpus: 'hdfc upi debit to biller vpa, cta tail "to report"'
+    const HDFC_VPA: ContinuityFamily = {
+      staleName: 'stale-hdfc-vpa',
+      staleTemplate:
+        '<CUR><AMT>00.00 debited from a/c **<NUM> on <NUM>-<NUM>-<NUM> to VPA <MERCH>(UPI Ref No <NUM>). Not you? Call on <NUM> to report',
+      status: PATTERN_STATUS.Approved,
+      samples: [
+        'Rs 589.00 debited from a/c **5432 on 29-05-19 to VPA billdesk.airtel-postpaid@icici(UPI Ref No 543210987654). Not you? Call on 54321098765 to report',
+        'Rs 1,249.00 debited from a/c **5432 on 14-08-19 to VPA billdesk.tneb@icici(UPI Ref No 543210912345). Not you? Call on 54321098765 to report',
+      ],
+      fresh:
+        'Rs 60.00 debited from a/c **5432 on 02-01-20 to VPA storeskm@okicici(UPI Ref No 543219876543). Not you? Call on 54321098765 to report',
+    }
+
+    // corpus: 'sbi upi transfer, amount without currency marker'
+    const SBI_TRF: ContinuityFamily = {
+      staleName: 'stale-sbi-trf',
+      staleTemplate:
+        'Dear UPI user A/C X<NUM> debited by <AMT>0.0 on date <NUM><MERCH> Refno <NUM>. If not u? call <NUM>. -SBI',
+      status: PATTERN_STATUS.Approved,
+      samples: [
+        'Dear UPI user A/C X5432 debited by 50.0 on date 05May24 trf to Mr Arun Prakash Refno 543210987654. If not u? call 5432109876. -SBI',
+        'Dear UPI user A/C X5432 debited by 250.0 on date 18Jun24 trf to Mrs Kavitha R Refno 543210955555. If not u? call 5432109876. -SBI',
+      ],
+      fresh:
+        'Dear UPI user A/C X5432 debited by 1500.0 on date 02Jul24 trf to PARKING PLAZA Refno 543210911111. If not u? call 5432109876. -SBI',
+    }
+
+    // corpus: 'icici credit card spend with Avl Lmt tail' — rejected, so this family
+    // also covers suppression continuity (the PR #46 bug class: rejected patterns
+    // resurfacing after a normalizer change).
+    const ICICI_CARD: ContinuityFamily = {
+      staleName: 'stale-icici-card',
+      staleTemplate:
+        '<CUR> <AMT>0.00 spent on ICICI Bank Card XX<NUM> at IND*<MERCH> -. Avl Lmt: <CUR> <NUM>. To dispute,call <NUM>/SMS BLOCK <NUM> to <NUM>',
+      status: PATTERN_STATUS.Rejected,
+      samples: [
+        'INR 920.00 spent on ICICI Bank Card XX5432 on 13-Oct-23 at IND*Amazon.in -. Avl Lmt: INR 2,63,617.00. To dispute,call 18002662/SMS BLOCK 4321 to 5432109876',
+        'INR 1,499.00 spent on ICICI Bank Card XX5432 on 02-Nov-23 at IND*Flipkart.com -. Avl Lmt: INR 1,13,618.00. To dispute,call 18002662/SMS BLOCK 4321 to 5432109876',
+      ],
+      fresh:
+        'INR 75.50 spent on ICICI Bank Card XX5432 on 25-Dec-23 at IND*Zomato.in -. Avl Lmt: INR 98,760.00. To dispute,call 18002662/SMS BLOCK 4321 to 5432109876',
+    }
+
+    const FAMILIES = [HDFC_VPA, SBI_TRF, ICICI_CARD]
+
+    function toCandidates<T extends { groupingPattern: string }>(rows: T[]) {
+      return rows.map((row) => ({
+        value: row,
+        groupingPattern: row.groupingPattern,
+        bigrams: bigrams(row.groupingPattern),
+      }))
+    }
+
+    async function seedFamilies() {
+      const idByStaleName = new Map<string, number>()
+      for (const family of FAMILIES) {
+        const row = await insertPattern({
+          name: family.staleName,
+          groupingPattern: family.staleTemplate,
+          status: family.status,
+        })
+        sampleStore[family.staleName] = family.samples.map((body, i) => makeSample({ body, smsId: 800 + i }))
+        idByStaleName.set(family.staleName, row.id)
+      }
+      return idByStaleName
+    }
+
+    it('recomputed patterns keep matching fresh messages of their format, and rejected ones keep suppressing', async () => {
+      const idByStaleName = await seedFamilies()
+
+      const summary = await recomputeStaleGroupingPatterns(db)
+      expect(summary).toEqual({ recomputed: 3, merged: 0, deleted: 0, stampedOnly: 0 })
+
+      const rows = await allRows()
+      expect(rows).toHaveLength(3)
+      for (const row of rows) {
+        expect(row.normalizerVersion).toBe(NORMALIZER_VERSION)
+      }
+
+      // Match the way sms-sync-service does: normalized fresh body against
+      // active/rejected candidates (exact fast path, Dice >= 0.8 fallback).
+      const active = toCandidates(rows.filter((r) => r.status !== PATTERN_STATUS.Rejected))
+      const rejected = toCandidates(rows.filter((r) => r.status === PATTERN_STATUS.Rejected))
+
+      const hdfcMatch = matchPattern(normalizeSMSTemplate(HDFC_VPA.fresh), active)
+      expect(hdfcMatch?.value.id).toBe(idByStaleName.get(HDFC_VPA.staleName))
+
+      const sbiMatch = matchPattern(normalizeSMSTemplate(SBI_TRF.fresh), active)
+      expect(sbiMatch?.value.id).toBe(idByStaleName.get(SBI_TRF.staleName))
+
+      const suppressed = matchPattern(normalizeSMSTemplate(ICICI_CARD.fresh), rejected)
+      expect(suppressed?.value.id).toBe(idByStaleName.get(ICICI_CARD.staleName))
+    })
+
+    it('a later discovery of the same format upserts into the recomputed row instead of duplicating', async () => {
+      await seedFamilies()
+      await recomputeStaleGroupingPatterns(db)
+
+      const [hdfcRow] = (await allRows()).filter((r) => r.groupingPattern === normalizeSMSTemplate(HDFC_VPA.samples[0]))
+      expect(hdfcRow).toBeDefined()
+
+      // Hash stability is what makes the upsert land on the same row: a fresh message
+      // of the format must normalize to exactly the recomputed groupingPattern.
+      const freshTemplate = normalizeSMSTemplate(HDFC_VPA.fresh)
+      expect(freshTemplate).toBe(hdfcRow.groupingPattern)
+
+      const draft: DistinctPattern = {
+        id: '1',
+        template: 'Rs <AMT> debited from a/c **5432 to VPA <MERCHANT>',
+        groupingTemplate: freshTemplate,
+        occurrences: 1,
+        transactions: [],
+        patternType: TRANSACTION_TYPE.Debit,
+        status: PATTERN_STATUS.NeedsReview,
+      }
+      await upsertPatternsByGrouping([draft])
+
+      const rows = await allRows()
+      expect(rows).toHaveLength(3) // updated in place — no fourth row
+      const [updated] = rows.filter((r) => r.id === hdfcRow.id)
+      expect(updated.name).toBe(murmurHash32(freshTemplate))
+      expect(updated.normalizerVersion).toBe(NORMALIZER_VERSION) // conflict path restamps too
+    })
   })
 })

--- a/src/services/migrations/normalizer-recompute-migration.spec.ts
+++ b/src/services/migrations/normalizer-recompute-migration.spec.ts
@@ -166,7 +166,7 @@ describe('recomputeStaleGroupingPatterns', () => {
 
     const summary = await recomputeStaleGroupingPatterns(db)
 
-    expect(summary).toEqual({ renamed: 1, merged: 0, deleted: 0, stampedOnly: 0 })
+    expect(summary).toEqual({ recomputed: 1, merged: 0, deleted: 0, stampedOnly: 0 })
 
     const [updated] = await db.select().from(patterns).where(eq(patterns.id, row.id))
     expect(updated.name).toBe(CURRENT_NAME)
@@ -196,17 +196,22 @@ describe('recomputeStaleGroupingPatterns', () => {
     })
     const sms201 = await insertSms()
     const sms202 = await insertSms()
-    const sms203 = await insertSms() // shared by both patterns' links below — must dedupe after repoint
+    const sms203 = await insertSms()
 
+    // Sample-level overlap on sms202, placed BEFORE the cap boundary so an undeduped
+    // union would waste a slot on the duplicate and silently drop sms203 entirely
+    // (a naive slice(0, 3) of [201, 202, 202-dup, 203] never reaches 203).
     sampleStore['legacy-a'] = [
       makeSample({ body: CURRENT_BODIES[0], smsId: sms201.id }),
-      makeSample({ body: CURRENT_BODIES[1], smsId: sms203.id }),
+      makeSample({ body: CURRENT_BODIES[1], smsId: sms202.id }),
     ]
     sampleStore['legacy-b'] = [
-      makeSample({ body: CURRENT_BODIES[2], smsId: sms202.id }),
+      makeSample({ body: CURRENT_BODIES[1], smsId: sms202.id }),
       makeSample({ body: CURRENT_BODIES[0], smsId: sms203.id }),
     ]
 
+    // Link-level overlap on sms203 (independent of the sample overlap above) — must
+    // dedupe after repoint too.
     await insertLink(rowA.id, sms201.id)
     await insertLink(rowA.id, sms203.id)
     await insertLink(rowB.id, sms202.id)
@@ -216,7 +221,7 @@ describe('recomputeStaleGroupingPatterns', () => {
 
     // rowA is processed first and claims the converged name via a rename (neither row
     // started out named that); rowB then collides into it and merges.
-    expect(summary).toEqual({ renamed: 1, merged: 1, deleted: 0, stampedOnly: 0 })
+    expect(summary).toEqual({ recomputed: 1, merged: 1, deleted: 0, stampedOnly: 0 })
 
     const rows = await allRows()
     expect(rows).toHaveLength(1)
@@ -229,11 +234,62 @@ describe('recomputeStaleGroupingPatterns', () => {
 
     expect(sampleStore['legacy-a']).toBeUndefined()
     expect(sampleStore['legacy-b']).toBeUndefined()
-    expect(sampleStore[CURRENT_NAME]).toHaveLength(3) // 4 unioned, capped at SAMPLES_PER_PATTERN
+    // Deduped by smsId first, then capped — all 3 distinct messages survive instead of
+    // wasting a slot on the sms202 duplicate and losing sms203.
+    const unionedSmsIds = sampleStore[CURRENT_NAME].map((s) => s.smsId).sort((a, b) => a - b)
+    expect(unionedSmsIds).toEqual([sms201.id, sms202.id, sms203.id].sort((a, b) => a - b))
 
     const links = await linksFor(survivor.id)
     const smsIds = links.map((l) => l.smsId).sort((a, b) => a - b)
     expect(smsIds).toEqual([sms201.id, sms202.id, sms203.id].sort((a, b) => a - b)) // 203 deduped, not doubled
+  })
+
+  it("preserves a merge survivor's accumulated state across a 3-way collision within one sweep", async () => {
+    // Processing order (ascending id) matters here: B and C must merge into A's slot
+    // BEFORE A itself is reprocessed, so A's own pass is the one at risk of resetting
+    // the map to its stale pre-sweep usageCount and silently dropping B's and C's
+    // contributions — a loss only D's later merge would actually surface.
+    await insertPattern({
+      name: 'legacy-b-3way',
+      groupingPattern: '<CUR><AMT>00.00 legacy b 3way',
+      usageCount: 10,
+    })
+    await insertPattern({
+      name: 'legacy-c-3way',
+      groupingPattern: '<CUR> <AMT> legacy c 3way',
+      usageCount: 100,
+    })
+    // Already current-format but stale only from the pre-fix stamping gap, so its own
+    // recompute is a no-op rename onto its own name — exactly the shape that risks
+    // re-seeding the running survivor state instead of preserving it.
+    const rowA = await insertPattern({
+      name: CURRENT_NAME,
+      groupingPattern: CURRENT_TEMPLATE,
+      usageCount: 1,
+    })
+    await insertPattern({
+      name: 'legacy-d-3way',
+      groupingPattern: '<CUR><AMT>00.00 legacy d 3way',
+      usageCount: 1000,
+    })
+
+    sampleStore['legacy-b-3way'] = [makeSample({ body: CURRENT_BODIES[0], smsId: 901 })]
+    sampleStore['legacy-c-3way'] = [makeSample({ body: CURRENT_BODIES[1], smsId: 902 })]
+    sampleStore[CURRENT_NAME] = [makeSample({ body: CURRENT_BODIES[2], smsId: 903 })]
+    sampleStore['legacy-d-3way'] = [makeSample({ body: CURRENT_BODIES[0], smsId: 904 })]
+
+    const summary = await recomputeStaleGroupingPatterns(db)
+
+    expect(summary.recomputed).toBe(1) // rowA's own no-op rename
+    expect(summary.merged).toBe(3) // B, then C, then D — all into rowA
+
+    const rows = await allRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].id).toBe(rowA.id)
+    // If rowA's reprocessing had reset the running total to its own stale pre-sweep
+    // usageCount (1), rowD's merge would land on 1 + 1000 = 1001, silently dropping
+    // rowB's and rowC's contributions instead of the correct sum of all four.
+    expect(rows[0].usageCount).toBe(10 + 100 + 1 + 1000)
   })
 
   it('resolves an approved-vs-rejected collision by latest updatedAt and logs a warning', async () => {
@@ -272,7 +328,7 @@ describe('recomputeStaleGroupingPatterns', () => {
 
     const summary = await recomputeStaleGroupingPatterns(db)
 
-    expect(summary).toEqual({ renamed: 0, merged: 0, deleted: 1, stampedOnly: 0 })
+    expect(summary).toEqual({ recomputed: 0, merged: 0, deleted: 1, stampedOnly: 0 })
     const remaining = await db.select().from(patterns).where(eq(patterns.id, row.id))
     expect(remaining).toHaveLength(0)
     expect(await linksFor(row.id)).toHaveLength(0)
@@ -288,7 +344,7 @@ describe('recomputeStaleGroupingPatterns', () => {
 
     const summary = await recomputeStaleGroupingPatterns(db)
 
-    expect(summary).toEqual({ renamed: 0, merged: 0, deleted: 0, stampedOnly: 1 })
+    expect(summary).toEqual({ recomputed: 0, merged: 0, deleted: 0, stampedOnly: 1 })
     const [updated] = await db.select().from(patterns).where(eq(patterns.id, row.id))
     expect(updated.name).toBe('orphan-approved')
     expect(updated.groupingPattern).toBe('<CUR><AMT>00.00 orphan approved')
@@ -296,6 +352,38 @@ describe('recomputeStaleGroupingPatterns', () => {
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(`pattern ${row.id}`))
 
     warnSpy.mockRestore()
+  })
+
+  describe('samples present but unusable (every body normalizes to empty)', () => {
+    it('deletes a needs-review row instead of crashing the sweep', async () => {
+      const row = await insertPattern({ name: 'blank-needs-review', status: PATTERN_STATUS.NeedsReview })
+      sampleStore['blank-needs-review'] = [makeSample({ body: '   ' }), makeSample({ body: '' })]
+
+      const summary = await recomputeStaleGroupingPatterns(db)
+
+      expect(summary).toEqual({ recomputed: 0, merged: 0, deleted: 1, stampedOnly: 0 })
+      expect(await db.select().from(patterns).where(eq(patterns.id, row.id))).toHaveLength(0)
+    })
+
+    it('stamps an approved row without recomputing instead of crashing the sweep', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      const row = await insertPattern({
+        name: 'blank-approved',
+        groupingPattern: '<CUR><AMT>00.00 blank approved',
+        status: PATTERN_STATUS.Approved,
+      })
+      sampleStore['blank-approved'] = [makeSample({ body: '' })]
+
+      const summary = await recomputeStaleGroupingPatterns(db)
+
+      expect(summary).toEqual({ recomputed: 0, merged: 0, deleted: 0, stampedOnly: 1 })
+      const [updated] = await db.select().from(patterns).where(eq(patterns.id, row.id))
+      expect(updated.groupingPattern).toBe('<CUR><AMT>00.00 blank approved')
+      expect(updated.normalizerVersion).toBe(NORMALIZER_VERSION)
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('no usable samples'))
+
+      warnSpy.mockRestore()
+    })
   })
 
   describe('first-run sweep (the stamping-gap: rows already current-format but stamped at the default 1)', () => {
@@ -309,7 +397,7 @@ describe('recomputeStaleGroupingPatterns', () => {
 
       const summary = await recomputeStaleGroupingPatterns(db)
 
-      expect(summary).toEqual({ renamed: 1, merged: 0, deleted: 0, stampedOnly: 0 })
+      expect(summary).toEqual({ recomputed: 1, merged: 0, deleted: 0, stampedOnly: 0 })
       const [updated] = await db.select().from(patterns).where(eq(patterns.id, row.id))
       expect(updated.name).toBe(CURRENT_NAME)
       expect(updated.groupingPattern).toBe(CURRENT_TEMPLATE)
@@ -326,7 +414,7 @@ describe('recomputeStaleGroupingPatterns', () => {
 
       const summary = await recomputeStaleGroupingPatterns(db)
 
-      expect(summary).toEqual({ renamed: 0, merged: 0, deleted: 1, stampedOnly: 0 })
+      expect(summary).toEqual({ recomputed: 0, merged: 0, deleted: 1, stampedOnly: 0 })
       expect(await db.select().from(patterns).where(eq(patterns.id, row.id))).toHaveLength(0)
     })
   })
@@ -336,7 +424,7 @@ describe('recomputeStaleGroupingPatterns', () => {
 
     const summary = await recomputeStaleGroupingPatterns(db)
 
-    expect(summary).toEqual({ renamed: 0, merged: 0, deleted: 0, stampedOnly: 0 })
+    expect(summary).toEqual({ recomputed: 0, merged: 0, deleted: 0, stampedOnly: 0 })
   })
 
   it('is safe to run twice — the second run touches nothing', async () => {
@@ -344,9 +432,9 @@ describe('recomputeStaleGroupingPatterns', () => {
     sampleStore['legacy-idempotent'] = CURRENT_BODIES.map((body) => makeSample({ body }))
 
     const first = await recomputeStaleGroupingPatterns(db)
-    expect(first.renamed).toBe(1)
+    expect(first.recomputed).toBe(1)
 
     const second = await recomputeStaleGroupingPatterns(db)
-    expect(second).toEqual({ renamed: 0, merged: 0, deleted: 0, stampedOnly: 0 })
+    expect(second).toEqual({ recomputed: 0, merged: 0, deleted: 0, stampedOnly: 0 })
   })
 })

--- a/src/services/migrations/normalizer-recompute-migration.ts
+++ b/src/services/migrations/normalizer-recompute-migration.ts
@@ -1,6 +1,7 @@
 import * as schema from '@/db/schema'
 import { PATTERN_STATUS, patterns, patternSmsGroup, type Pattern } from '@/db/schema'
 import { getDrizzleDb } from '@/services/database/db'
+import { SAMPLES_PER_PATTERN } from '@/types/constants'
 import { murmurHash32 } from '@/utils/hash/murmur32'
 import {
   deletePatternSamplesByName,
@@ -13,13 +14,12 @@ import { eq, inArray, lt } from 'drizzle-orm'
 import type { BaseSQLiteDatabase } from 'drizzle-orm/sqlite-core'
 import type { Migration } from './migration-runner'
 
-const SAMPLES_PER_PATTERN = 3
-
 /** Loose enough to accept both the production expo-sqlite instance and an injected test driver. */
 export type RecomputeCapableDb = BaseSQLiteDatabase<'sync' | 'async', any, typeof schema>
 
 export interface RecomputeSummary {
-  renamed: number
+  /** Rows whose name/groupingPattern were (re)computed in place — includes no-op restamps. */
+  recomputed: number
   merged: number
   deleted: number
   stampedOnly: number
@@ -51,11 +51,13 @@ function toSurvivorState(row: Pattern): SurvivorState {
   }
 }
 
-function pickMajorityTemplate(bodies: string[]): string {
+/** Null when every body normalizes to '' (corrupt/empty MMKV entries) — nothing usable to recompute from. */
+function pickMajorityTemplate(bodies: string[]): string | null {
   const groups = groupByTemplate(
     bodies.map((body) => ({ body })),
     (item) => normalizeSMSTemplate(item.body)
   )
+  if (groups.length === 0) return null
   const [winner] = [...groups].sort((a, b) => b.items.length - a.items.length)
   return winner.groupingPattern
 }
@@ -66,7 +68,7 @@ function pickMajorityTemplate(bodies: string[]): string {
  * SMS. See docs/NORMALIZER_VERSIONING.md for the full algorithm and rationale.
  */
 export async function recomputeStaleGroupingPatterns(db: RecomputeCapableDb): Promise<RecomputeSummary> {
-  const summary: RecomputeSummary = { renamed: 0, merged: 0, deleted: 0, stampedOnly: 0 }
+  const summary: RecomputeSummary = { recomputed: 0, merged: 0, deleted: 0, stampedOnly: 0 }
 
   const allRows: Pattern[] = await db.select().from(patterns)
   const staleRows = allRows.filter((row) => row.normalizerVersion < NORMALIZER_VERSION)
@@ -82,8 +84,11 @@ export async function recomputeStaleGroupingPatterns(db: RecomputeCapableDb): Pr
   await db.transaction(async (tx) => {
     for (const row of staleRows) {
       const samples = getPatternSamplesByName(row.name)
+      const newTemplate = samples.length > 0 ? pickMajorityTemplate(samples.map((s) => s.body)) : null
 
-      if (samples.length === 0) {
+      if (!newTemplate) {
+        // Either no samples, or every sample body normalized to '' (corrupt/empty
+        // entries) — nothing usable to recompute from either way.
         if (row.status === PATTERN_STATUS.NeedsReview) {
           await tx.delete(patternSmsGroup).where(eq(patternSmsGroup.patternId, row.id))
           await tx.delete(patterns).where(eq(patterns.id, row.id))
@@ -91,14 +96,13 @@ export async function recomputeStaleGroupingPatterns(db: RecomputeCapableDb): Pr
         } else {
           await tx.update(patterns).set({ normalizerVersion: NORMALIZER_VERSION }).where(eq(patterns.id, row.id))
           console.warn(
-            `normalizer-recompute: pattern ${row.id} (${row.status}) has no samples — stamped without recompute`
+            `normalizer-recompute: pattern ${row.id} (${row.status}) has no usable samples — stamped without recompute`
           )
           summary.stampedOnly += 1
         }
         continue
       }
 
-      const newTemplate = pickMajorityTemplate(samples.map((s) => s.body))
       const newName = murmurHash32(newTemplate)
       const existing = survivorByName.get(newName)
 
@@ -117,10 +121,20 @@ export async function recomputeStaleGroupingPatterns(db: RecomputeCapableDb): Pr
         if (newName !== row.name) {
           setPatternSamplesByName(newName, samples.slice(0, SAMPLES_PER_PATTERN))
           deletePatternSamplesByName(row.name)
+          survivorByName.delete(row.name)
         }
 
-        survivorByName.set(newName, { ...toSurvivorState(row), id: row.id })
-        summary.renamed += 1
+        // Only seed from this row's own pre-sweep snapshot when nobody occupied
+        // newName yet. When existing.id === row.id, `existing` may already carry
+        // state folded in from an earlier collision this sweep (row can be a merge
+        // survivor and still show up here later, e.g. an already-current-format row
+        // that's stale only from the pre-fix stamping gap) — resetting it to row's
+        // original snapshot would silently drop that earlier merge's contribution.
+        if (!existing) {
+          survivorByName.set(newName, toSurvivorState(row))
+        }
+
+        summary.recomputed += 1
         continue
       }
 
@@ -131,10 +145,6 @@ export async function recomputeStaleGroupingPatterns(db: RecomputeCapableDb): Pr
       const mergedCreatedAt =
         row.createdAt.getTime() < existing.createdAt.getTime() ? row.createdAt : existing.createdAt
       const mergedOriginalUpdatedAt = rowIsNewer ? row.updatedAt : existing.updatedAt
-
-      const survivorSamples = getPatternSamplesByName(newName)
-      setPatternSamplesByName(newName, [...survivorSamples, ...samples].slice(0, SAMPLES_PER_PATTERN))
-      if (row.name !== newName) deletePatternSamplesByName(row.name)
 
       await tx
         .update(patterns)
@@ -162,6 +172,23 @@ export async function recomputeStaleGroupingPatterns(db: RecomputeCapableDb): Pr
       }
 
       await tx.delete(patterns).where(eq(patterns.id, row.id))
+
+      // MMKV last: if a crash lands between the SQL above and here, the loser row is
+      // already gone from the table, so it can't be reprocessed — but it also can't
+      // be stranded as a duplicate. Doing this before the SQL (as an earlier version
+      // did) let a crash leave the loser stamped-current-but-unmerged forever, since
+      // the no-samples branch above would find its key already moved and never retry.
+      const survivorSamples = getPatternSamplesByName(newName)
+      const seenSampleSmsIds = new Set<number>()
+      const unionedSamples = [...survivorSamples, ...samples]
+        .filter((sample) => {
+          if (seenSampleSmsIds.has(sample.smsId)) return false
+          seenSampleSmsIds.add(sample.smsId)
+          return true
+        })
+        .slice(0, SAMPLES_PER_PATTERN)
+      setPatternSamplesByName(newName, unionedSamples)
+      if (row.name !== newName) deletePatternSamplesByName(row.name)
 
       survivorByName.set(newName, {
         id: existing.id,
@@ -194,7 +221,7 @@ export const normalizerRecomputeMigration: Migration = {
   run: async () => {
     const summary = await recomputeStaleGroupingPatterns(getDrizzleDb())
     console.warn(
-      `normalizer-recompute: renamed=${summary.renamed} merged=${summary.merged} deleted=${summary.deleted} stampedOnly=${summary.stampedOnly}`
+      `normalizer-recompute: recomputed=${summary.recomputed} merged=${summary.merged} deleted=${summary.deleted} stampedOnly=${summary.stampedOnly}`
     )
   },
 }

--- a/src/services/migrations/normalizer-recompute-migration.ts
+++ b/src/services/migrations/normalizer-recompute-migration.ts
@@ -1,0 +1,200 @@
+import * as schema from '@/db/schema'
+import { PATTERN_STATUS, patterns, patternSmsGroup, type Pattern } from '@/db/schema'
+import { getDrizzleDb } from '@/services/database/db'
+import { murmurHash32 } from '@/utils/hash/murmur32'
+import {
+  deletePatternSamplesByName,
+  getPatternSamplesByName,
+  setPatternSamplesByName,
+} from '@/utils/mmkv/pattern-samples'
+import { groupByTemplate } from '@/utils/pattern/group-by-template'
+import { NORMALIZER_VERSION, normalizeSMSTemplate } from '@/utils/pattern/normalize-sms-template'
+import { eq, inArray, lt } from 'drizzle-orm'
+import type { BaseSQLiteDatabase } from 'drizzle-orm/sqlite-core'
+import type { Migration } from './migration-runner'
+
+const SAMPLES_PER_PATTERN = 3
+
+/** Loose enough to accept both the production expo-sqlite instance and an injected test driver. */
+export type RecomputeCapableDb = BaseSQLiteDatabase<'sync' | 'async', any, typeof schema>
+
+export interface RecomputeSummary {
+  renamed: number
+  merged: number
+  deleted: number
+  stampedOnly: number
+}
+
+/**
+ * Tracks, per current grouping-pattern name, which row now owns it and the ORIGINAL
+ * status/usageCount/createdAt/updatedAt it carried before this sweep touched anything.
+ * Collision tie-breaks always compare these original values, never a timestamp this
+ * sweep just wrote — otherwise whichever stale row happens to be processed first would
+ * always look "more recently decided" than one processed later, purely from sweep
+ * ordering, and could silently overturn a genuinely later user decision on the other row.
+ */
+interface SurvivorState {
+  id: number
+  status: Pattern['status']
+  usageCount: number
+  createdAt: Date
+  updatedAt: Date
+}
+
+function toSurvivorState(row: Pattern): SurvivorState {
+  return {
+    id: row.id,
+    status: row.status,
+    usageCount: row.usageCount,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  }
+}
+
+function pickMajorityTemplate(bodies: string[]): string {
+  const groups = groupByTemplate(
+    bodies.map((body) => ({ body })),
+    (item) => normalizeSMSTemplate(item.body)
+  )
+  const [winner] = [...groups].sort((a, b) => b.items.length - a.items.length)
+  return winner.groupingPattern
+}
+
+/**
+ * Recomputes grouping patterns for rows stamped with a stale normalizerVersion, so a
+ * normalizer rule change never orphans patterns, MMKV samples, or resurfaces rejected
+ * SMS. See docs/NORMALIZER_VERSIONING.md for the full algorithm and rationale.
+ */
+export async function recomputeStaleGroupingPatterns(db: RecomputeCapableDb): Promise<RecomputeSummary> {
+  const summary: RecomputeSummary = { renamed: 0, merged: 0, deleted: 0, stampedOnly: 0 }
+
+  const allRows: Pattern[] = await db.select().from(patterns)
+  const staleRows = allRows.filter((row) => row.normalizerVersion < NORMALIZER_VERSION)
+  if (staleRows.length === 0) return summary
+
+  const survivorByName = new Map<string, SurvivorState>(allRows.map((row) => [row.name, toSurvivorState(row)]))
+
+  // Note: drizzle-orm's expo-sqlite driver commits as soon as this callback's first
+  // `await` yields, so this provides no real rollback-on-error atomicity in production
+  // (same limitation sms-encryption-migration.ts already has). Correctness instead
+  // relies on every row below being processed idempotently, so a crash mid-sweep is
+  // safe to resume — never on the SQL transaction undoing a partial sweep.
+  await db.transaction(async (tx) => {
+    for (const row of staleRows) {
+      const samples = getPatternSamplesByName(row.name)
+
+      if (samples.length === 0) {
+        if (row.status === PATTERN_STATUS.NeedsReview) {
+          await tx.delete(patternSmsGroup).where(eq(patternSmsGroup.patternId, row.id))
+          await tx.delete(patterns).where(eq(patterns.id, row.id))
+          summary.deleted += 1
+        } else {
+          await tx.update(patterns).set({ normalizerVersion: NORMALIZER_VERSION }).where(eq(patterns.id, row.id))
+          console.warn(
+            `normalizer-recompute: pattern ${row.id} (${row.status}) has no samples — stamped without recompute`
+          )
+          summary.stampedOnly += 1
+        }
+        continue
+      }
+
+      const newTemplate = pickMajorityTemplate(samples.map((s) => s.body))
+      const newName = murmurHash32(newTemplate)
+      const existing = survivorByName.get(newName)
+
+      if (!existing || existing.id === row.id) {
+        // Rename in place — a no-op restamp when newName already equals row.name.
+        await tx
+          .update(patterns)
+          .set({
+            name: newName,
+            groupingPattern: newTemplate,
+            normalizerVersion: NORMALIZER_VERSION,
+            updatedAt: new Date(),
+          })
+          .where(eq(patterns.id, row.id))
+
+        if (newName !== row.name) {
+          setPatternSamplesByName(newName, samples.slice(0, SAMPLES_PER_PATTERN))
+          deletePatternSamplesByName(row.name)
+        }
+
+        survivorByName.set(newName, { ...toSurvivorState(row), id: row.id })
+        summary.renamed += 1
+        continue
+      }
+
+      // Collision — two formats now normalize identically. Merge `row` into `existing`.
+      const rowIsNewer = row.updatedAt.getTime() > existing.updatedAt.getTime()
+      const mergedStatus = rowIsNewer ? row.status : existing.status
+      const mergedUsageCount = existing.usageCount + row.usageCount
+      const mergedCreatedAt =
+        row.createdAt.getTime() < existing.createdAt.getTime() ? row.createdAt : existing.createdAt
+      const mergedOriginalUpdatedAt = rowIsNewer ? row.updatedAt : existing.updatedAt
+
+      const survivorSamples = getPatternSamplesByName(newName)
+      setPatternSamplesByName(newName, [...survivorSamples, ...samples].slice(0, SAMPLES_PER_PATTERN))
+      if (row.name !== newName) deletePatternSamplesByName(row.name)
+
+      await tx
+        .update(patterns)
+        .set({
+          status: mergedStatus,
+          usageCount: mergedUsageCount,
+          createdAt: mergedCreatedAt,
+          updatedAt: new Date(),
+          normalizerVersion: NORMALIZER_VERSION,
+        })
+        .where(eq(patterns.id, existing.id))
+
+      await tx.update(patternSmsGroup).set({ patternId: existing.id }).where(eq(patternSmsGroup.patternId, row.id))
+
+      // The losing row's links now point at the survivor too — dedupe (patternId, smsId).
+      const links = await tx.select().from(patternSmsGroup).where(eq(patternSmsGroup.patternId, existing.id))
+      const seenSmsIds = new Set<number>()
+      const duplicateLinkIds: number[] = []
+      for (const link of [...links].sort((a, b) => a.id - b.id)) {
+        if (seenSmsIds.has(link.smsId)) duplicateLinkIds.push(link.id)
+        else seenSmsIds.add(link.smsId)
+      }
+      if (duplicateLinkIds.length > 0) {
+        await tx.delete(patternSmsGroup).where(inArray(patternSmsGroup.id, duplicateLinkIds))
+      }
+
+      await tx.delete(patterns).where(eq(patterns.id, row.id))
+
+      survivorByName.set(newName, {
+        id: existing.id,
+        status: mergedStatus,
+        usageCount: mergedUsageCount,
+        createdAt: mergedCreatedAt,
+        updatedAt: mergedOriginalUpdatedAt,
+      })
+      summary.merged += 1
+      console.warn(`normalizer-recompute: merged pattern ${row.id} into ${existing.id} (status=${mergedStatus})`)
+    }
+  })
+
+  return summary
+}
+
+async function hasStaleGroupingPatterns(db: RecomputeCapableDb): Promise<boolean> {
+  const stale = await db
+    .select({ id: patterns.id })
+    .from(patterns)
+    .where(lt(patterns.normalizerVersion, NORMALIZER_VERSION))
+    .limit(1)
+  return stale.length > 0
+}
+
+export const normalizerRecomputeMigration: Migration = {
+  id: 'normalizer-recompute',
+  name: 'Normalizer grouping pattern recompute',
+  shouldRun: () => hasStaleGroupingPatterns(getDrizzleDb()),
+  run: async () => {
+    const summary = await recomputeStaleGroupingPatterns(getDrizzleDb())
+    console.warn(
+      `normalizer-recompute: renamed=${summary.renamed} merged=${summary.merged} deleted=${summary.deleted} stampedOnly=${summary.stampedOnly}`
+    )
+  },
+}

--- a/src/services/sms-parsing/pattern-discovery-service.ts
+++ b/src/services/sms-parsing/pattern-discovery-service.ts
@@ -1,5 +1,6 @@
 import { PATTERN_STATUS, TRANSACTION_TYPE } from '@/db/schema'
 import { upsertPatternsByGrouping } from '@/services/database/patterns-repository'
+import { SAMPLES_PER_PATTERN } from '@/types/constants'
 import type { ReviewTxn } from '@/types/sms-parsing'
 import type { DistinctPattern } from '@/types/sms/transaction'
 import { murmurHash32 } from '@/utils/hash/murmur32'
@@ -10,8 +11,6 @@ import { reconcileGroupSamples } from '@/utils/pattern/reconcile-group-samples'
 import { SMSDataExtractor } from './sms-data-extractor-service'
 import { SMSReaderService } from './sms-reader-service'
 import { SmsSyncService, type CandidateSms } from './sms-sync-service'
-
-const SAMPLES_PER_PATTERN = 3
 
 interface CandidateSample {
   candidate: CandidateSms

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -1,1 +1,4 @@
 export const DB_NAME = 'rose_wallet'
+
+/** Max review samples kept per pattern (MMKV discovery samples and post-recompute unions). */
+export const SAMPLES_PER_PATTERN = 3

--- a/src/utils/mmkv/pattern-samples.ts
+++ b/src/utils/mmkv/pattern-samples.ts
@@ -29,3 +29,16 @@ export function setPatternSamplesByName(name: string, samples: ReviewTxn[]) {
     storage.set(MMKV_KEYS.PATTERNS.DISCOVERY_SAMPLES_V2, JSON.stringify(map))
   }
 }
+
+export function deletePatternSamplesByName(name: string): void {
+  const json = storage.getString(MMKV_KEYS.PATTERNS.DISCOVERY_SAMPLES_V2)
+  if (!json) return
+  try {
+    const map = JSON.parse(json) as Record<string, ReviewTxn[]>
+    if (!(name in map)) return
+    delete map[name]
+    storage.set(MMKV_KEYS.PATTERNS.DISCOVERY_SAMPLES_V2, JSON.stringify(map))
+  } catch {
+    // Corrupt map — nothing to delete safely.
+  }
+}


### PR DESCRIPTION
## Summary

Implements `docs/NORMALIZER_VERSIONING.md`, so a future `NORMALIZER_VERSION` bump no longer requires asking users to clear app data (the workaround used for the v1→v2 bump during closed beta).

- **Stamp on write**: `upsertPatternsByGrouping` now stamps `normalizerVersion` on both insert and the conflict-update set — previously it wrote neither, so every pattern row (even freshly-discovered v2 ones) silently sat at the DB default.
- **Recompute on upgrade**: new `recomputeStaleGroupingPatterns()` migration, registered in `appMigrations`, runs at startup only when stale rows exist. For each stale row it re-normalizes MMKV sample bodies with the current normalizer and either renames in place, merges into a colliding row (latest-decision-wins on status, usage summed, `patternSmsGroup` links repointed and deduped), or — when samples are missing — deletes `needs-review` rows and stamps approved/rejected rows in place with a warning logged.
- **Framework change**: `Migration.shouldRun` widened from `() => boolean` to `() => boolean | Promise<boolean>` (the staleness check is a DB query), with the runner's filter changed to a sequential awaited loop so the pending-list accounting stays accurate.
- Fixed an unrelated pre-existing lint warning (`category-selector.spec.tsx`'s unused `MAX_CATEGORIES` import) by wiring the two boundary tests to derive their selection from the real constant instead of a disconnected hardcoded `4`.

## Test plan

- [x] `pnpm test` — 79 suites / 450 tests passing, including new coverage for rename, merge (with collision, status tie-break, and `patternSmsGroup` dedup), delete/stamp-only no-sample branches, the first-run "whole table at default" sweep, and double-run idempotency
- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)